### PR TITLE
Max Amount Ammo Fix

### DIFF
--- a/src/actors/Weapons/AssaultShotgun.dec
+++ b/src/actors/Weapons/AssaultShotgun.dec
@@ -367,7 +367,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		"####" "#" 0 a_jumpifinventory("ASGReloadToken",1,"Inspect")
 		"####" "#" 0 a_jumpifinventory("HoldInspect",1,"InspectHold") 
 		"####" "#" 0 A_JUMPIFINVENTORY("IsInspecting",1,"Inspect2")
-		"####" "#" 0 A_JumpIfInventory("AssaultShotgunAmmo",20,"Inspect")
+		"####" "#" 0 A_JumpIfInventory("AssaultShotgunAmmo",0,"Inspect")
 		//"####" "#" 1 A_WeaponReady(WRF_NOBOB|WRF_NOFIRE|WRF_ALLOWZOOM)
 		USAS A 0 A_JumpIfInventory("AmmoShell",1,3)
 		Goto NoAmmo
@@ -510,7 +510,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		TNT1 AAAA 0
 		tnt1 a 0 a_GIVEinventory("ASGReloadToken",1)
 		TNT1 A 0 A_TakeInventory("HasUnloadedASG",1)
-		USAS A 0 A_JumpIfInventory("AssaultShotgunAmmo",20,"CR3")
+		USAS A 0 A_JumpIfInventory("AssaultShotgunAmmo",0,"CR3")
 		USAS A 0 A_JumpIfInventory("AmmoShell",1,3)
 		Goto CR3
 		TNT1 AAAAAA 0
@@ -528,7 +528,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 
 	InsertBullets2:
 		TNT1 AAAA 0
-		USAS A 0 A_JumpIfInventory("AssaultShotgunAmmo",20,"CR2")
+		USAS A 0 A_JumpIfInventory("AssaultShotgunAmmo",0,"CR2")
 		USAS A 0 A_JumpIfInventory("AmmoShell",1,3)
 		Goto CR2
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/DUalRifle.dec
+++ b/src/actors/Weapons/DUalRifle.dec
@@ -347,7 +347,7 @@ ACTOR DualRifles : BrutalWeapon
 		DURI A 0 A_Takeinventory("ADSmode",1)
 		DURI A 0 A_Takeinventory("Zoomed",1)
 		DURI A 0 A_JumpIfInventory("NoReloading",1,"Ready3")
-		DURI A 0 A_JumpIfInventory("DoubleRifleAmmo",62,"Ready3")
+		DURI A 0 A_JumpIfInventory("DoubleRifleAmmo",0,"Ready3")
 		DURI A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		DURI A 0 A_JumpIfInventory("Clip2",1,3)
 		Goto NoAmmo
@@ -421,7 +421,7 @@ ACTOR DualRifles : BrutalWeapon
 
 	InsertBullets2:
 		TNT1 AAAA 0
-		DURI A 0 A_JumpIfInventory("DoubleRifleAmmo",62,15)
+		DURI A 0 A_JumpIfInventory("DoubleRifleAmmo",0,15)
 		DURI A 0 A_JumpIfInventory("Clip2",1,3)
 		Goto FinishReloading
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/DualMP40.dec
+++ b/src/actors/Weapons/DualMP40.dec
@@ -203,7 +203,7 @@ ACTOR DualMP40 : BrutalWeapon
 		TNT1 A 0 A_Takeinventory("Zoomed",1)
 		TNT1 A 0 A_Takeinventory("ADSmode",1)
 		TNT1 A 0 A_JumpIfInventory("NoReloading",1,"Ready")
-		TNT1 A 0 A_JumpIfInventory("DualMP40Ammo",64,"Ready")
+		TNT1 A 0 A_JumpIfInventory("DualMP40Ammo",0,"Ready")
 		TNT1 A 0 A_JumpIfInventory("Mauser9mm",1,3)
 		Goto NoAmmo
 		TNT1 AAA 0
@@ -253,7 +253,7 @@ ACTOR DualMP40 : BrutalWeapon
 
 	InsertBullets:
 		TNT1 AAAA 0
-		TNT1 A 0 A_JumpIfInventory("DualMP40Ammo",64,15)
+		TNT1 A 0 A_JumpIfInventory("DualMP40Ammo",0,15)
 		TNT1 A 0 A_JumpIfInventory("Mauser9mm",1,3)
 		Goto Ready
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/DualPistol.dec
+++ b/src/actors/Weapons/DualPistol.dec
@@ -411,7 +411,7 @@ ACTOR DualPistols : BrutalWeapon
 		PI2G A 0 A_Takeinventory("ADSmode",1)
 		PI2G A 0 A_JumpIfInventory("NoReloading",1,"Ready")
 		PI2G A 1 A_WEAPONREADY(WRF_NOBOB|WRF_NOFIRE|WRF_ALLOWZOOM)
-		PI2G A 0 A_JumpIfInventory("BDDualPistolAmmo",32,"Ready")
+		PI2G A 0 A_JumpIfInventory("BDDualPistolAmmo",0,"Ready")
 		PI2G A 0 A_JumpIfInventory("Clip1",1,3)
 		Goto NoAmmo
 		TNT1 AAA 0
@@ -473,7 +473,7 @@ ACTOR DualPistols : BrutalWeapon
 
 	InsertBullets2:
 		TNT1 AAAA 0
-		PI2G A 0 A_JumpIfInventory("BDDualPistolAmmo",32,15)
+		PI2G A 0 A_JumpIfInventory("BDDualPistolAmmo",0,15)
 		PI2G A 0 A_JumpIfInventory("Clip1",1,3)
 		Goto Ready
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/DualPlasma.dec
+++ b/src/actors/Weapons/DualPlasma.dec
@@ -229,7 +229,7 @@ ACTOR DualPlasmaRifles : BrutalWeapon
 		DUPR A 0 A_JumpIfInventory("NoReloading",1,"Ready")
 		DUPR A 0 A_JumpIfInventory("AmmoCell",1,1)
 		Goto Ready
-		DUPR A 0 A_JumpIfInventory("DoublePlasmaAmmo",100,"Ready")
+		DUPR A 0 A_JumpIfInventory("DoublePlasmaAmmo",0,"Ready")
 		DUPR A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		DUPR FGHI 1 A_WEAPONREADY(WRF_NOBOB|WRF_NOFIRE|WRF_ALLOWZOOM)
 		TNT1 A 8 A_WEAPONREADY(WRF_NOBOB|WRF_NOFIRE|WRF_ALLOWZOOM)
@@ -259,7 +259,7 @@ ACTOR DualPlasmaRifles : BrutalWeapon
 		PRSG F 0 A_Takeinventory("HasUnloadedDualPlasmas",1)
 	ReloadingSequence:
 		TNT1 AAAAAAAAAA 0
-		DUPR A 0 A_JumpIfInventory("DoublePlasmaAmmo",100,15)
+		DUPR A 0 A_JumpIfInventory("DoublePlasmaAmmo",0,15)
 		DUPR A 0 A_JumpIfInventory("AmmoCell",1,3)
 		Goto Ready
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/DualSMG.dec
+++ b/src/actors/Weapons/DualSMG.dec
@@ -266,7 +266,7 @@ ACTOR DualSMG : BrutalWeapon
 		SM2F A 0 A_Takeinventory("ADSmode",1)
 		SM2F A 0 A_Takeinventory("Zoomed",1)
 		SM2F A 0 A_JumpIfInventory("NoReloading",1,"Ready")
-		SM2F A 0 A_JumpIfInventory("BDDualSMGAmmo",82,"Ready")
+		SM2F A 0 A_JumpIfInventory("BDDualSMGAmmo",0,"Ready")
 		SM2F A 0 A_JumpIfInventory("Clip1",1,3)
 		Goto NoAmmo
 		TNT1 AAA 0
@@ -329,7 +329,7 @@ ACTOR DualSMG : BrutalWeapon
 
 	InsertBullets2:
 		TNT1 AAAA 0
-		SM2F A 0 A_JumpIfInventory("BDDualSMGAmmo",82,15)
+		SM2F A 0 A_JumpIfInventory("BDDualSMGAmmo",0,15)
 		SM2F A 0 A_JumpIfInventory("Clip1",1,3)
 		Goto Ready
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/Mp40.dec
+++ b/src/actors/Weapons/Mp40.dec
@@ -373,7 +373,7 @@ ACTOR MP40 : BrutalWeapon
 		MP40 A 0 A_Takeinventory("Zoomed",1)
 		MP40 A 0 A_Takeinventory("ZoomHold",1)
 		MP40 A 0 A_JumpIfinventory("MP40ReloadToken",1,"Fidget")
-		MP40 A 0 A_JumpIfInventory("MP40Ammo",32,"Fidget")
+		MP40 A 0 A_JumpIfInventory("MP40Ammo",0,"Fidget")
 		MP40 A 0 A_JumpIfInventory("Mauser9mm",1,3)
 		Goto Ready//NoAmmo
 		TNT1 AAA 0
@@ -400,7 +400,7 @@ ACTOR MP40 : BrutalWeapon
 	InsertBullets2:
 		TNT1 AAAA 0
 		MP40 A 0 A_GiveInventory("MP40ReloadToken",1)
-		MP40 A 0 A_JumpIfInventory("MP40Ammo",32,15)
+		MP40 A 0 A_JumpIfInventory("MP40Ammo",0,15)
 		MP40 A 0 A_JumpIfInventory("Mauser9mm",1,3)
 		Goto FullReload
 		TNT1 AAAAAA 0
@@ -442,7 +442,7 @@ ACTOR MP40 : BrutalWeapon
 		3P4R ABCDEEEEEEEFGHIIJJJ 1 A_WEAPONREADY(WRF_NOBOB|WRF_NOFIRE|WRF_ALLOWZOOM)
 	InsertBullets:
 		TNT1 AAAA 0
-		MP40 A 0 A_JumpIfInventory("MP40Ammo",32,15)
+		MP40 A 0 A_JumpIfInventory("MP40Ammo",0,15)
 		MP40 A 0 A_JumpIfInventory("Mauser9mm",1,3)
 		Goto ContinueReloading
 		TNT1 AAAAAA 0
@@ -565,7 +565,7 @@ ACTOR MP40 : BrutalWeapon
 
 	TurboReload:
 		TNT1 AAAA 0
-		MP40 A 0 A_JumpIfInventory("MP40Ammo",32,15)
+		MP40 A 0 A_JumpIfInventory("MP40Ammo",0,15)
 		MP40 A 0 A_JumpIfInventory("Mauser9mm",1,3)
 		Goto Ready3//+6
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/Pistol.dec
+++ b/src/actors/Weapons/Pistol.dec
@@ -350,7 +350,7 @@ ACTOR BrutalPistol : BrutalWeapon
 		"####" "#" 0 A_Takeinventory("ADSmode",1)
 		"####" "#" 0 A_JumpIfInventory("IsPlayingAsPurist", 1,"PuristWarning")
 		"####" "#" 0 A_JumpIfInventory("HoldInspect",1,"Inspect2")
-		PIST E 0 A_JumpIfInventory("BDPistolAmmo",16,"Inspect")
+		PIST E 0 A_JumpIfInventory("BDPistolAmmo",0,"Inspect")
 		PIST E 0 A_JumpIfInventory("Clip1",1,3)
 		Goto Ready
 		TNT1 AAA 0
@@ -405,7 +405,7 @@ ACTOR BrutalPistol : BrutalWeapon
 		PIST E 0 A_PlaySound("Pistol/Reload2", 5)
 	InsertBullets2:
 		TNT1 AAAA 0
-		PIST E 0 A_JumpIfInventory("BDPistolAmmo",16,15)
+		PIST E 0 A_JumpIfInventory("BDPistolAmmo",0,15)
 		PIST E 0 A_JumpIfInventory("Clip1",1,3)
 		Goto FinishReload2
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/Plasma.dec
+++ b/src/actors/Weapons/Plasma.dec
@@ -741,7 +741,7 @@ ACTOR Plasma_Gun : BrutalWeapon
 		PRSG F 0 A_Takeinventory("Reloading",1)
 		PRSG F 0 A_ClearReFire
 		PRSG F 0 A_JumpIfInventory("PlasmaCharging",1,"Cancel")
-		PRSG F 0 A_JumpIfInventory("PlasmaAmmo",50,"Ready")
+		PRSG F 0 A_JumpIfInventory("PlasmaAmmo",0,"Ready")
 		PRSG F 0 A_JumpIfInventory("AmmoCell",1,3)
 		Goto Ready
 		TNT1 AAAA 0
@@ -756,7 +756,7 @@ ACTOR Plasma_Gun : BrutalWeapon
 		PRSR OOOO 1 A_WEAPONREADY(WRF_NOBOB|WRF_NOFIRE|WRF_ALLOWZOOM)
 	ReloadingSequence:
 		TNT1 AAAAAAAAAA 0
-		PRSG F 0 A_JumpIfInventory("PlasmaAmmo",50,15)
+		PRSG F 0 A_JumpIfInventory("PlasmaAmmo",0,15)
 		PRSG F 0 A_JumpIfInventory("AmmoCell",1,3)
 		Goto FinishReload
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/Railgun.dec
+++ b/src/actors/Weapons/Railgun.dec
@@ -471,7 +471,7 @@ Actor RailGun : BrutalWeapon
 		TNT1 A 0 A_SetCrosshair( CallACS("GetCrosshair", 11) )
 		2HTN E 0 A_JumpIfInventory("IsPlayingAsPurist", 1,"PuristWarning")
 		RAIL A 0 A_JumpIfInventory("NoReloading", 1, "Fidget")
-		RAIL A 0 A_JumpIfInventory("RailgunAmmo",5,"Fidget")
+		RAIL A 0 A_JumpIfInventory("RailgunAmmo",0,"Fidget")
 		RAIL A 0 A_JumpIfInventory("AmmoCell",10,3)
 		Goto Ready
 		TNT1 AAAA 0
@@ -489,7 +489,7 @@ Actor RailGun : BrutalWeapon
 
 	InsertBullets:
 		TNT1 AAAA 0
-		RAIL A 0 A_JumpIfInventory("RailgunAmmo",5,"FinishReload")
+		RAIL A 0 A_JumpIfInventory("RailgunAmmo",0,"FinishReload")
 		RAIL A 0 A_JumpIfInventory("AmmoCell",10,3)
 		Goto FinishReload
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/Revolver.dec
+++ b/src/actors/Weapons/Revolver.dec
@@ -259,7 +259,7 @@ ACTOR Revolver : BrutalWeapon 5874
 		REVO A 0 A_Takeinventory("Zoomed",1)
 		REVO A 0 A_ZoomFactor(1.0)
 		REVO A 0 A_JumpIfInventory("HoldTheRevolver",1,"Inspect2")
-		REVO A 0 A_JumpIfInventory("RevolverAmmo",6,"Inspect")
+		REVO A 0 A_JumpIfInventory("RevolverAmmo",0,"Inspect")
 		REVO A 0 A_JumpIfInventory("HasUnloadedRevolver", 1, "ReloadUnloaded")
 		REVO A 0 A_JumpIfInventory("TurboReload", 1, "TurboReload")//Check if reloads are disabled.
 		REVR B 0 A_GiveInventory ("Pumping", 1)
@@ -279,7 +279,7 @@ ACTOR Revolver : BrutalWeapon 5874
 		SSHR A 0 A_TakeInventory("Reloading", 1)
 		TNT1 A 0 A_JumpIfInventory("HasUnloadedRevolver",1,3)
 		TNT1 A 0 A_FireCustomMissile("SSGCaseSpawner",0,0,-10, -20)
-		REVO A 0 A_JumpIfInventory("RevolverAmmo",6,"FinishedInsertingShells")
+		REVO A 0 A_JumpIfInventory("RevolverAmmo",0,"FinishedInsertingShells")
 		REVO A 0 A_Giveinventory("RevolverAmmo",1)
 		REVO A 0 A_JumpIfInventory("NoReloading",1,2)
 		REVO A 0 A_Takeinventory("AmmoShell",1,TIF_NOTAKEINFINITE)
@@ -293,7 +293,7 @@ ACTOR Revolver : BrutalWeapon 5874
 		SSHR A 0 A_JumpIfInventory("Reloading", 1, "FinishedInsertingShells")
 		REVO A 0 A_JumpIfInventory("Kicking",1,"DoKick")  //A_JumpIfInventory("Kicking",1,"DoKickReloading") Too inconsistent and unpolished for this beta,you'll work on this later!
 		REVO A 0 A_JumpIfInventory("IsRunning",1,"StartSprint")
-		REVO A 0 A_JumpIfInventory("RevolverAmmo",6,"FinishedInsertingShells")//If there are 8+1 shells, stop it immediately
+		REVO A 0 A_JumpIfInventory("RevolverAmmo",0,"FinishedInsertingShells")//If there are 8+1 shells, stop it immediately
 		Goto InsertingShells
 
 	FinishedInsertingShells:
@@ -310,7 +310,7 @@ ACTOR Revolver : BrutalWeapon 5874
 		SHSS BC 0
 	TurboBullets:
 		REVO A 0
-		REVO A 0 A_JumpIfInventory("RevolverAmmo",6,"FinishTurboReload")
+		REVO A 0 A_JumpIfInventory("RevolverAmmo",0,"FinishTurboReload")
 		REVO A 0 A_JumpIfInventory("AmmoShell",1,3)
 		Goto FinishTurboReload
 		TNT1 AAAA 0
@@ -330,7 +330,7 @@ ACTOR Revolver : BrutalWeapon 5874
 		TNT1 A 0 A_PlaySound("Shotgun/Reload", 5)
 	InsertBullets:
 		TNT1 AAAA 0
-		REVO A 0 A_JumpIfInventory("RevolverAmmo",6,"FinishUnloadedReload")
+		REVO A 0 A_JumpIfInventory("RevolverAmmo",0,"FinishUnloadedReload")
 		REVO A 0 A_JumpIfInventory("AmmoShell",1,3)
 		Goto FinishUnloadedReload
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/Rifle.dec
+++ b/src/actors/Weapons/Rifle.dec
@@ -712,7 +712,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		"####" "#" 0 A_JumpIfInventory("HoldInspect", 1, "InspectHold")
 		"####" "#" 0 A_JumpIfInventory("IsInspecting", 1, "Inspect2")
-		RIFG A 0 A_JumpIfInventory("RifleAmmo",31,"Inspect")
+		RIFG A 0 A_JumpIfInventory("RifleAmmo",0,"Inspect")
 		RIFG A 0 A_JumpIfInventory("RifleReloadToken",1,"Inspect")
 		RIFG A 0 A_Takeinventory("Reloading",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
@@ -792,7 +792,7 @@ ACTOR Rifle : BrutalWeapon
 
 	InsertBullets2:
 		TNT1 AAAA 0
-		RIFG A 0 A_JumpIfInventory("RifleAmmo",31,15)
+		RIFG A 0 A_JumpIfInventory("RifleAmmo",0,15)
 		RIFG A 0 A_JumpIfInventory("Clip2",1,3)
 		Goto FullReload
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/RocketLauncher.dec
+++ b/src/actors/Weapons/RocketLauncher.dec
@@ -474,7 +474,7 @@ ACTOR Rocket_Launcher : BrutalWeapon
 		MISG A 0 A_Takeinventory("PowerLightAmp", 1)
 		TNT1 A 0 A_SetCrosshair( CallACS("GetCrosshair", 8) )
 		MISG A 0 A_JumpIfInventory("HasUnloadedRL", 1, "ReloadUnloaded")
-		MISG A 0 A_JumpIfInventory("RocketRounds",6,"NoNeedToReload")
+		MISG A 0 A_JumpIfInventory("RocketRounds",0,"NoNeedToReload")
 		MISG A 0 A_JumpIfInventory("AmmoRocket",1,3)
 		Goto Ready
 		TNT1 AAAA 0
@@ -495,7 +495,7 @@ ACTOR Rocket_Launcher : BrutalWeapon
 
 	FinishReload:
 		TNT1 AAAAAA 0
-		MISG A 0 A_JumpIfInventory("RocketRounds",6,"FinishReloadAnim")
+		MISG A 0 A_JumpIfInventory("RocketRounds",0,"FinishReloadAnim")
 		MISG A 0 A_JumpIfInventory("AmmoRocket",1,3)
 		Goto FinishReloadAnim
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/Shotgun.dec
+++ b/src/actors/Weapons/Shotgun.dec
@@ -242,7 +242,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		"####" A 0 A_Takeinventory("ShotgunWasEmpty",1)
 		"####" H 0 A_PlaySound("Shotgun/Pump2", 5)
 		"####" A 0 A_JumpIfInventory("NoReloading",1,13)
-		"####" A 0 A_JumpIfInventory("ShotgunAmmo",9,12)
+		"####" A 0 A_JumpIfInventory("ShotgunAmmo",0,12)
 		"####" PQ 1 A_JumpIfInventory("Reloading",1,"ReloadFromPumping")
 		"####" FEDCB 1 A_JumpIfInventory("Reloading",1,"ReloadFromPumping")
 		"####" A 0 A_JumpIfInventory("ShotgunAmmo",1,2)
@@ -269,7 +269,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN KLMN 1
 		SHTN A 0 A_Takeinventory("ShotgunWasEmpty",1)
 		SHTN H 0 A_PlaySound("Shotgun/Pump2", 5)
-		SHTN A 0 A_JumpIfInventory("ShotgunAmmo",9,18)
+		SHTN A 0 A_JumpIfInventory("ShotgunAmmo",0,18)
 		SHTN PQ 1 A_JumpIfInventory("Reloading",1,"ReloadFromPumping")
 		SHTN FEDCB 1 A_JumpIfInventory("Reloading",1,"ReloadFromPumping")
 		SHTN A 0 A_JumpIfInventory("FiredSecondary",1,"AltFire")
@@ -480,7 +480,7 @@ ACTOR Shot_Gun : BrutalWeapon
 
 	ReloadFromPumping:
 		SHTN A 0 A_Takeinventory("Reloading",1)
-		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",9,"Pump2")
+		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",0,"Pump2")
 		SHTN A 0 A_JumpIfInventory("AmmoShell", 1, 2)
 		Goto Pump2+38
 		SHTN AA 0
@@ -504,7 +504,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		TNT1 A 0 A_SetCrosshair( CallACS("GetCrosshair", 5) )
 		SHTN A 0 A_JumpIfInventory("HoldInspect",1,"Inspect2")
 		SHTN A 0 A_JumpIfInventory("IsInspecting",1,"ContinueInspect2")
-		SHTN A 0 A_JumpIfInventory("ShotgunAmmo",9,"Inspect")
+		SHTN A 0 A_JumpIfInventory("ShotgunAmmo",0,"Inspect")
 		SHTN A 0 A_JumpIfInventory("ShotgunAmmo", 1, "ReloadNormally")//Check if there is a shell in the chamber
 		SHTN A 0 A_GiveInventory("ShotgunWasEmpty", 1)//This means there is no shell in the chamber
 	ReloadNormally:
@@ -525,7 +525,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN AAA 0
 		SHTN A 0 A_GiveInventory ("Pumping", 1)
 		SSHR AA 0 A_TakeInventory("Reloading", 1)
-		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",9,"CheckIfFinishReload")
+		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",0,"CheckIfFinishReload")
 		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",8,"CheckIfFinishReload")
 		SHTN A 0 A_Giveinventory("ShotgunAmmo",1)
 		SHTN A 0 A_Takeinventory("AmmoShell",1,TIF_NOTAKEINFINITE)
@@ -539,7 +539,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN AA 0 A_JumpIfInventory("Reloading", 1, "Pump2")
 		SHTN AA 0 A_JumpIfInventory("Kicking",1,"DoKickReloading")// Too inconsistent and unpolished for this beta,you'll work on this later!
 		SHTN AA 0 A_JumpIfInventory("IsRunning",1,"StartSprint")
-		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",9,"FinishedInsertingShells")//If there are 8+1 shells, stop it immediately
+		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",0,"FinishedInsertingShells")//If there are 8+1 shells, stop it immediately
 		Goto InsertingShells
 
 	CheckIfFinishReload:
@@ -564,7 +564,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHSS BC 0
 	TurboBullets:
 		SHTN A 0
-		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",9,"FinishTurboReload")
+		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",0,"FinishTurboReload")
 		SHTN A 0 A_JumpIfInventory("AmmoShell",1,3)
 		Goto FinishTurboReload
 		TNT1 AAAA 0
@@ -580,7 +580,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHSS BC 0
 	TurboBullets2:
 		SHTN A 0
-		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",9,"FinishTurboReload")
+		SHTN AA 0 A_JumpIfInventory("ShotgunAmmo",0,"FinishTurboReload")
 		SHTN A 0 A_JumpIfInventory("AmmoShell",1,3)
 		Goto FinishTurboReload2
 		TNT1 AAAA 0

--- a/src/actors/Weapons/Sniper.dec
+++ b/src/actors/Weapons/Sniper.dec
@@ -529,7 +529,7 @@ ACTOR Sniper : BrutalWeapon
 		x21G A 0 A_Takeinventory("ADSmode",1)
 		x21G A 0 A_Takeinventory("Zoomed",1)
 		TNT1 A 0 A_TakeInventory("SniperAim", 1)
-		x21G A 0 A_JumpIfInventory("xm21Ammo",11,"ready3")
+		x21G A 0 A_JumpIfInventory("xm21Ammo",0,"ready3")
 		x21G A 0 A_JumpIfInventory("SniperAmmo",1,3)
 		Goto FinishReloading
 		TNT1 AAA 0
@@ -567,7 +567,7 @@ ACTOR Sniper : BrutalWeapon
 
 	InsertBullets2:
 		TNT1 AAAA 0
-		x21G A 0 A_JumpIfInventory("xm21Ammo",11,15)
+		x21G A 0 A_JumpIfInventory("xm21Ammo",0,15)
 		x21G A 0 A_JumpIfInventory("SniperAmmo",1,3)
 		Goto FinishReload2
 		TNT1 AAAAAA 0

--- a/src/actors/Weapons/SubMachinegun.dec
+++ b/src/actors/Weapons/SubMachinegun.dec
@@ -379,7 +379,7 @@ ACTOR BrutalSMG : BrutalWeapon
 		SMGR A 0 A_Takeinventory("ADSmode",1)
 		SMGR A 0 A_Takeinventory("Zoomed",1)
 		SMGR A 0 A_Takeinventory("ZoomHold",1)
-		SMGR A 0 A_JumpIfInventory("BDSMGAmmo",41,"Ready")
+		SMGR A 0 A_JumpIfInventory("BDSMGAmmo",0,"Ready")
 
 		SMGR A 0 A_JumpIfInventory("Clip1",1,3)
 		Goto NoAmmo
@@ -433,7 +433,7 @@ ACTOR BrutalSMG : BrutalWeapon
 
 	InsertBullets2:
 		TNT1 AAAA 0
-		SMGR A 0 A_JumpIfInventory("BDSMGAmmo",41,15)
+		SMGR A 0 A_JumpIfInventory("BDSMGAmmo",0,15)
 		SMGR A 0 A_JumpIfInventory("Clip1",1,3)
 		Goto FinishReload
 		TNT1 AAAAAA 0


### PR DESCRIPTION
The fix changes the ammo inventory value to 0 as it determines the maximum amount initially, this is useful for Gun Bonsai users when using ammo. Zandronum works just as well for users