### PR TITLE
Cleanup stuff

### DIFF
--- a/src/DECORATE.txt
+++ b/src/DECORATE.txt
@@ -289,7 +289,7 @@ Actor RandomIcon 1337
 	states
 	{
 	Spawn:
-		RAND O 1
+		RAND O -1
 		Loop	
 	}
 }	

--- a/src/actors/DECORATIONS/FIREWORKS.dec
+++ b/src/actors/DECORATIONS/FIREWORKS.dec
@@ -383,8 +383,8 @@ ACTOR BarrelShrapnel1
 	States
 	{
 	Spawn:
-		TNT1 A 0 NODELAY A_SetScale(frandom(1.0,1.7))
-		TNT1 A 0 A_JumpIf(waterlevel > 1, "Underwater")
+		BRPT A 0 NODELAY A_SetScale(frandom(1.0,1.7))
+		BRPT A 0 A_JumpIf(waterlevel > 1, "Underwater")
 		BRPT ABCDEFGH 1
 		TNT1 A 0 A_ChangeFlag("NOGRAVITY", 0)
 		Goto Spawn2
@@ -980,10 +980,6 @@ Actor BarrelExplosionDamage
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		Goto Death
-
-	Death:
 		TNT1 A 0
 		TNT1 A 0 A_Explode(200,200)
 		Stop

--- a/src/actors/DECORATIONS/FIREWORKS.dec
+++ b/src/actors/DECORATIONS/FIREWORKS.dec
@@ -424,7 +424,7 @@ ACTOR BarrelShrapnel4: BarrelShrapnel1
 actor GreatKaboom
 {
 	Game Doom
-	Renderstyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	+CLIENTSIDEONLY
 	States
@@ -441,7 +441,7 @@ actor GreatKaboom
 actor UltraKaboom: GreatKaboom
 {
 	Game Doom
-	Renderstyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	-CLIENTSIDEONLY
 	States
@@ -458,7 +458,7 @@ actor UltraKaboom: GreatKaboom
 actor BarrelKaboom: GreatKaboom
 {
 	Game Doom
-	Renderstyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	States
 	{
@@ -472,7 +472,7 @@ actor BarrelKaboom: GreatKaboom
 actor BarrelKaboomSilent: GreatKaboom
 {
 	Game Doom
-	Renderstyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	States
 	{
@@ -486,7 +486,7 @@ actor BarrelKaboomSilent: GreatKaboom
 actor BigExplosion1112: GreatKaboom
 {
 	Game Doom
-	Renderstyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	States
 	{
@@ -536,7 +536,7 @@ Actor ExplosionSpawner
 	radius 6
 	height 6
 	speed 40
-	renderstyle none
+	RenderStyle "None"
 	alpha 0.9
 	scale .01
 	BounceFactor 0.5
@@ -674,7 +674,7 @@ Actor SpawnedExplosion
 	+NOINTERACTION
 	+NOBLOCKMAP
 	+CLIENTSIDEONLY
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -692,7 +692,7 @@ Actor SpawnedExplosionSilent
 	+NOINTERACTION
 	+NOBLOCKMAP
 	+CLIENTSIDEONLY
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -709,7 +709,7 @@ Actor SpawnedExplosionRepeat
 	+NOINTERACTION
 	+NOBLOCKMAP
 	+CLIENTSIDEONLY
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -732,7 +732,7 @@ Actor SpawnedExplosionBig
 	+NOINTERACTION
 	+NOBLOCKMAP
 	+CLIENTSIDEONLY
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -754,7 +754,7 @@ Actor SpawnedExplosionLarge
 	+NOGRAVITY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -773,7 +773,7 @@ Actor SpawnedExplosionLarge2
 	+NOGRAVITY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -791,7 +791,7 @@ Actor SpawnedExplosionGiant
 	+NOGRAVITY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -808,7 +808,7 @@ Actor SpawnedFlamers
 	+NOCLIP
 	+NOGRAVITY
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	DamageType Flames
 	states
 	{
@@ -826,7 +826,7 @@ Actor SpawnedExplosionSmall
 	+NOGRAVITY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -849,7 +849,7 @@ Actor SpawnedExplosionSmall
 	Speed 2
 	Damagetype "Fire"
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -878,7 +878,7 @@ Actor SpawnedExplosionNuke2
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -900,7 +900,7 @@ Actor RocketPenetrationExplosion
 	+NOGRAVITY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	DamageType "ExplosiveImpact"
 	states
 	{
@@ -934,7 +934,7 @@ ACTOR FireworkSFXType1
 	+THRUGHOST
 	+CLIENTSIDEONLY
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	-NOGRAVITY
 	Gravity 1
 	Alpha 1.0
@@ -976,7 +976,7 @@ Actor BarrelExplosionDamage
 	Speed 0
 	Damagetype "ExplosiveImpact"
 	+NOBLOCKMAP
-	renderstyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -997,7 +997,7 @@ Actor ExplosionFire
 	Radius 1
 	Height 1
 	Speed 4
-	RenderStyle add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -1010,7 +1010,7 @@ Actor ExplosionFire
 Actor ExplosionShrapnel: ExplosionFire
 {
 	Speed 0
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:

--- a/src/actors/DECORATIONS/Furniture.dec
+++ b/src/actors/DECORATIONS/Furniture.dec
@@ -170,9 +170,9 @@ ACTOR BDTallGreenColumn Replaces TallGreenColumn
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		"####" "#" 0 A_Jump(128,2)
-		"####" "#" 0 A_SetScale(-scalex,scaley)
+		COL1 A 0
+		COL1 A 0 A_Jump(128,2)
+		COL1 A 0 A_SetScale(-scalex,scaley)
 		COL1 A 35
 		TNT1 A 0 A_JumpIfInventory("MarkForDeletion", 1, "Disappear")
 		COL1 A -1
@@ -204,9 +204,9 @@ ACTOR BDShortGreenColumn Replaces ShortGreenColumn
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		"####" "#" 0 A_Jump(128,2)
-		"####" "#" 0 A_SetScale(-scalex,scaley)
+		COL2 A 0
+		COL2 A 0 A_Jump(128,2)
+		COL2 A 0 A_SetScale(-scalex,scaley)
 		COL2 A 35
 		TNT1 A 0 A_JumpIfInventory("MarkForDeletion", 1, "Disappear")
 		COL2 A -1
@@ -238,9 +238,9 @@ ACTOR BDTallRedColumn Replaces TallRedColumn
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		"####" "#" 0 A_Jump(128,2)
-		"####" "#" 0 A_SetScale(-scalex,scaley)
+		COL3 A 0
+		COL3 A 0 A_Jump(128,2)
+		COL3 A 0 A_SetScale(-scalex,scaley)
 		COL3 A 35
 		TNT1 A 0 A_JumpIfInventory("MarkForDeletion", 1, "Disappear")
 		COL3 A -1
@@ -272,9 +272,9 @@ ACTOR BDShortRedColumn replaces ShortRedColumn
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		"####" "#" 0 A_Jump(128,2)
-		"####" "#" 0 A_SetScale(-scalex,scaley)
+		COL4 A 0
+		COL4 A 0 A_Jump(128,2)
+		COL4 A 0 A_SetScale(-scalex,scaley)
 		COL4 A 1
 		//TNT1 A 0 A_SpawnItemEx("EvidenceCheckerRedPillar", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
 		COL4 A 35
@@ -308,9 +308,9 @@ ACTOR BDSkullColumn Replaces SkullColumn
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		"####" "#" 0 A_Jump(128,2)
-		"####" "#" 0 A_SetScale(-scalex,scaley)
+		COL6 A 0
+		COL6 A 0 A_Jump(128,2)
+		COL6 A 0 A_SetScale(-scalex,scaley)
 		COL6 A 35
 		TNT1 A 0 A_JumpIfInventory("MarkForDeletion", 1, "Disappear")
 		COL6 A -1
@@ -342,9 +342,9 @@ ACTOR BDHeartColumn Replaces HeartColumn
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		"####" "#" 0 A_Jump(128,2)
-		"####" "#" 0 A_SetScale(-scalex,scaley)
+		COL5 A 0
+		COL5 A 0 A_Jump(128,2)
+		COL5 A 0 A_SetScale(-scalex,scaley)
 		COL5 AB 14
 		TNT1 A 0 A_JumpIfInventory("MarkForDeletion", 1, "Disappear")
 		COL5 A 0 A_SpawnItemEX("SmallBloodPool", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION|SXF_CLIENTSIDE)

--- a/src/actors/DECORATIONS/Lamps.dec
+++ b/src/actors/DECORATIONS/Lamps.dec
@@ -51,7 +51,7 @@ Actor TechLamp1Flare
 {
 	//MONSTER
 	Health 1
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.5
 	+ISMONSTER
 	+SHOOTABLE
@@ -117,7 +117,7 @@ Actor BreakingLamp
 {
 	+NOINTERACTION
 	+CLIENTSIDEONLY
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -201,7 +201,7 @@ Actor Column1Flare
 {
 	Health 1
 	//Mass 0
-	renderstyle Add
+	RenderStyle "Add"
 	//radius 1
 	//height 2
 	alpha 0.5

--- a/src/actors/DECORATIONS/Natural.dec
+++ b/src/actors/DECORATIONS/Natural.dec
@@ -1,6 +1,6 @@
 ACTOR TreeBlood
 {
-	renderstyle none
+	RenderStyle "None"
 	alpha 1.0
 	-COUNTKILL
 	-SHOOTABLE

--- a/src/actors/DECORATIONS/Splashes.dec
+++ b/src/actors/DECORATIONS/Splashes.dec
@@ -21,12 +21,7 @@ Actor BloodParticleX
 	States
 	{
 	Spawn:
-		TNT1 A 1 
-		TNT1 A 0 A_ChangeFlag(DOOMBOUNCE, 0)
-		TNT1 A 1
-		Goto Stand
-
-	Stand:
+		BSPH A 0
 		BSPH ABCDDDDDD 4
 		Stop
 
@@ -113,6 +108,7 @@ Actor BloodLiquidParticleX
 	States
 	{
 	Spawn:
+		MSBL A 0
 		MSBL ABCDEFG 2
 		MSBL H 100
 		Stop
@@ -217,12 +213,7 @@ Actor nukageParticleX
 	States
 	{
 	Spawn:
-		TNT1 A 1 
-		TNT1 A 0 A_ChangeFlag(DOOMBOUNCE, 0)
-		TNT1 A 1
-		Goto Stand
-
-	Stand:
+		NKSH A 0 
 		NKSH ABCDDDDDD 4
 		Stop
 
@@ -397,12 +388,7 @@ Actor slimeParticleX
 	States
 	{
 	Spawn:
-		TNT1 A 1 
-		TNT1 A 0 A_ChangeFlag(DOOMBOUNCE, 0)
-		TNT1 A 1
-		Goto Stand
-
-	Stand:
+		SLIM A 1 
 		SLIM ABCDDDDDD 4
 		Stop
 
@@ -610,8 +596,8 @@ actor LavaSplashBase : slimeSplashBase
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_RadiusGive("IsOverLava", 64, RGF_OBJECTS, 1)
+		SLIM A 0
+		SLIM A 0 A_RadiusGive("IsOverLava", 64, RGF_OBJECTS, 1)
 		SLIM HI 6
 		SLIM HI 6
 		TNT1 A 0 A_NoBlocking
@@ -633,8 +619,8 @@ actor BDLavaSplashBase : slimeSplashBase
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_RadiusGive("IsOverBDLava", 64, RGF_OBJECTS, 1)
+		SLIM A 0
+		SLIM A 0 A_RadiusGive("IsOverBDLava", 64, RGF_OBJECTS, 1)
 		SLIM HI 6
 		SLIM HI 6
 		TNT1 A 0 A_NoBlocking

--- a/src/actors/DECORATIONS/Splashes.dec
+++ b/src/actors/DECORATIONS/Splashes.dec
@@ -14,7 +14,7 @@ Actor BloodParticleX
 	+CLIENTSIDEONLY
 	+NOTELEPORT
 	Gravity 0.5
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 1.0
 	Alpha 0.5
 	Speed 2
@@ -46,7 +46,7 @@ Actor BloodParticleXSpawner
 	radius 2
 	height 0
 	speed 30
-	renderstyle none
+	RenderStyle "None"
 	alpha 0.5
 	scale .15
 	states
@@ -75,7 +75,7 @@ Actor SpawnBloodLiquidParticleX
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	Renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -100,7 +100,7 @@ Actor BloodLiquidParticleX
 	+DontSplash
 	BounceFactor 0.1
 	Gravity 0.5
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Scale 2.0
 	Alpha 0.3
 	//decal BloodWaterDecal
@@ -133,7 +133,7 @@ actor BloodSplashBase3
 	+DONTSPLASH
 	+CLIENTSIDEONLY
 	+NOBLOCKMAP
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -205,7 +205,7 @@ Actor nukageParticleX
 	+CLIENTSIDEONLY
 	+NOTELEPORT
 	Gravity 0.5
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 1.0
 	Alpha 0.5
 	Speed 3
@@ -232,7 +232,7 @@ actor nukageSplashBase
 	Mass 9999999
 	alpha .6
 	Scale 1.5
-	RenderStyle none
+	RenderStyle "None"
 	+NOGRAVITY  
 	+THRUACTORS  
 	+DONTSPLASH  
@@ -332,7 +332,7 @@ Actor SpawnGreenLiquidParticleX
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	Renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -344,7 +344,7 @@ Actor SpawnGreenLiquidParticleX
 Actor GreenLiquidParticleX: BloodLiquidParticleX
 {
 	Translation "179:191=112:127"
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.8
 	//decal BloodWaterDecal
 	damagetype "Slime"
@@ -381,7 +381,7 @@ Actor slimeParticleX
 	+NOTELEPORT
 	BounceFactor 0.1
 	Gravity 0.5
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 1.0
 	Alpha 0.8
 	Speed 2
@@ -423,7 +423,7 @@ Actor SlimeParticleXSpawner
 	radius 2
 	height 0
 	speed 40
-	renderstyle none
+	RenderStyle "None"
 	alpha 0.9
 	scale .15
 	states
@@ -473,7 +473,7 @@ Actor SpawnBrownLiquidParticleX
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	Renderstyle none
+	RenderStyle "None"
 	states
 	{
 	Spawn:
@@ -485,7 +485,7 @@ Actor SpawnBrownLiquidParticleX
 Actor BrownLiquidParticleX: BloodLiquidParticleX
 {
 	Translation "179:191=144:151"
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.8
 	//decal BloodWaterDecal
 	damagetype "Slime"
@@ -511,7 +511,7 @@ actor slimeSplashBase
 	Mass 999999
 	alpha .8
 	Scale 1.5
-	Renderstyle none
+	RenderStyle "None"
 	+NOGRAVITY
 	+THRUACTORS
 	+DONTSPLASH

--- a/src/actors/DECORATIONS/Torches.dec
+++ b/src/actors/DECORATIONS/Torches.dec
@@ -38,9 +38,9 @@ Actor TallTorch_RedFlames : TallTorch_Red
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_Jump(128,"stay")
-		TNT1 A 0 A_SetScale(-scalex,scaley)
+		TRKR A 0
+		TRKR A 0 A_Jump(128,"stay")
+		TRKR A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		TRKR ABCDEFGHIJKL 1 BRIGHT
 		Loop
@@ -127,9 +127,9 @@ Actor TallTorch_BlueFlames : TallTorch_RedFlames
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_Jump(128,"stay")
-		TNT1 A 0 A_SetScale(-scalex,scaley)
+		TRKB A 0
+		TRKB A 0 A_Jump(128,"stay")
+		TRKB A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		TRKB ABCDEFGHIJKL 1 BRIGHT
 		Loop
@@ -199,9 +199,9 @@ Actor TallTorch_GreenFlames : TallTorch_Red
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_Jump(128,"stay")
-		TNT1 A 0 A_SetScale(-scalex,scaley)
+		TRKG A 0
+		TRKG A 0 A_Jump(128,"stay")
+		TRKG A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		TRKG ABCDEFGHIJKL 1 BRIGHT
 		Loop
@@ -293,9 +293,9 @@ Actor ShortTorch_BlueFlames : ShortTorch_Blue
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_Jump(128,"stay")
-		TNT1 A 0 A_SetScale(-scalex,scaley)
+		SRKB A 0
+		SRKB A 0 A_Jump(128,"stay")
+		SRKB A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		SRKB ABCDEFGHIJKL 1 BRIGHT
 		Loop
@@ -354,9 +354,9 @@ Actor ShortTorch_RedFlames : ShortTorch_Red
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_Jump(128,"stay")
-		TNT1 A 0 A_SetScale(-scalex,scaley)
+		SRKR A 0
+		SRKR A 0 A_Jump(128,"stay")
+		SRKR A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		SRKR ABCDEFGHIJKL 1 BRIGHT
 		Loop
@@ -414,9 +414,9 @@ Actor ShortTorch_GreenFlames : ShortTorch_Red
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_Jump(128,"stay")
-		TNT1 A 0 A_SetScale(-scalex,scaley)
+		SRKG A 0
+		SRKG A 0 A_Jump(128,"stay")
+		SRKG A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		SRKG ABCDEFGHIJKL 1 BRIGHT
 		Loop
@@ -525,9 +525,9 @@ Actor Candlestick1Flare : Candlestick
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		"####" "#" 0 A_Jump(128,2)
-		"####" "#" 0 A_SetScale(-scalex,scaley)
+		FSO1 A 0
+		FSO1 A 0 A_Jump(128,2)
+		FSO1 A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		FSO1 AB 1
 		Loop
@@ -689,8 +689,8 @@ Actor RedTF : TorchFlare
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_Jump(128,2)
+		FLAR A 0
+		FLAR A 0 A_Jump(128,2)
 		FLAR A 2 bright
 		stop
 		TNT1 A 0
@@ -897,10 +897,10 @@ ACTOR BDECTorch
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 ThrustThingZ(0, 50, 0, 1)
-		TNT1 A 1
-		TNT1 A 0 A_Stop
+		TORC A 0
+		TORC A 0 ThrustThingZ(0, 50, 0, 1)
+		TORC A 1
+		TORC A 0 A_Stop
 	Live:
 		TORC A 2 BRIGHT
 		TNT1 A 0 A_SpawnItem("YellowFlareSmall", 0, 30)

--- a/src/actors/DECORATIONS/Torches.dec
+++ b/src/actors/DECORATIONS/Torches.dec
@@ -31,7 +31,7 @@ Actor TallTorch_RedFlames : TallTorch_Red
 {
 	XScale 1.0
 	YScale 1.2
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+CLIENTSIDEONLY
 	+THRUACTORS
@@ -71,7 +71,7 @@ ACTOR TorchBall
 	+MOVEWITHSECTOR
 	+FORCEXYBILLBOARD
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	YScale 1.2
 	XScale 1.6
 	Radius 1
@@ -191,7 +191,7 @@ Actor TallTorch_GreenFlames : TallTorch_Red
 {
 	XScale 1.0
 	YScale 1.2
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+CLIENTSIDEONLY
 	+THRUACTORS
@@ -286,7 +286,7 @@ Actor ShortTorch_BlueFlames : ShortTorch_Blue
 {
 	XScale 1.0
 	YScale 1.2
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+CLIENTSIDEONLY
 	+THRUACTORS
@@ -347,7 +347,7 @@ Actor ShortTorch_RedFlames : ShortTorch_Red
 {
 	XScale 1.0
 	YScale 1.2
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+CLIENTSIDEONLY
 	+THRUACTORS
@@ -407,7 +407,7 @@ Actor ShortTorch_GreenFlames : ShortTorch_Red
 {
 	XScale 1.0
 	YScale 1.2
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+CLIENTSIDEONLY
 	+THRUACTORS
@@ -517,7 +517,7 @@ Actor Candlestick1Flare : Candlestick
 {
 	XScale 0.4
 	YScale 0.18
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.8
 	+CLIENTSIDEONLY
 	+FORCEXYBILLBOARD
@@ -678,7 +678,7 @@ Actor TorchFlare
 	+NOGRAVITY
 	+CLIENTSIDEONLY
 	+FORCEXYBILLBOARD
-	renderstyle Add
+	RenderStyle "Add"
 	radius 1
 	height 1
 	alpha 0.4

--- a/src/actors/Daisy.dec
+++ b/src/actors/Daisy.dec
@@ -370,7 +370,7 @@ ACTOR FriendDaisy_Guarding : FriendDaisy
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		DASY A 0
 		TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
 		DASY A 4
 		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
@@ -489,6 +489,7 @@ ACTOR DaisyPathfinder
 	damagefactor "SpawnMarine", 99999.0
 	MaxDropOffHeight 1200
 	MaxStepHeight 1200
+	RenderStyle "None"
 	-COUNTKILL
 	+NOTARGET
 	+THRUACTORS

--- a/src/actors/Dog.dec
+++ b/src/actors/Dog.dec
@@ -380,7 +380,7 @@ ACTOR FriendDog_Guarding : FriendDog
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		DOGS A 0
 		TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
 		DOGS A 4
 		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
@@ -503,6 +503,7 @@ ACTOR DogPathfinder
 	damagefactor "SpawnMarine", 99999.0
 	MaxDropOffHeight 1200
 	MaxStepHeight 1200
+	RenderStyle "None"
 	-COUNTKILL
 	+NOTARGET
 	+THRUACTORS

--- a/src/actors/Enemies/Arachnorb.dec
+++ b/src/actors/Enemies/Arachnorb.dec
@@ -235,7 +235,7 @@ ACTOR Aracnorb_Brain
 	States
 	{
 	Spawn:
-		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
+		ID22 A 0 A_JumpIf(waterlevel > 1, "Splash")
 		ID22 A 2 A_CustomMissile("BloodTrails",0,0,180,2)
 		ID22 B 2 A_CustomMissile("BloodTrails",0,0,180,2)
 		ID22 C 2 A_CustomMissile("BloodTrails",0,0,180,2)

--- a/src/actors/Enemies/ArchVile.dec
+++ b/src/actors/Enemies/ArchVile.dec
@@ -409,7 +409,7 @@ ACTOR ArchvileFire2 Replaces ArchvileFire
 	Game Doom
 	+NOBLOCKMAP +NOGRAVITY
 	+CLIENTSIDEONLY
-	RenderStyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:

--- a/src/actors/Enemies/ArchVile.dec
+++ b/src/actors/Enemies/ArchVile.dec
@@ -530,8 +530,8 @@ ACTOR DyingArchvileNoArm: TehArchvile
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_FaceTarget
+		VID2 A 0
+		VID2 A 0 A_FaceTarget
 		VID2 KKKLLL 2 A_CustomMissile ("ArterialBlood22Big", 24, 0, random (0, 360), 2, random (0, 45))
 		VID2 KKKLLL 2 A_CustomMissile ("ArterialBlood22Big", 24, 0, random (0, 360), 2, random (0, 45))
 		VID2 KKKLLL 2 A_CustomMissile ("ArterialBlood22Big", 24, 0, random (0, 360), 2, random (0, 45))

--- a/src/actors/Enemies/Baron.dec
+++ b/src/actors/Enemies/Baron.dec
@@ -1283,7 +1283,7 @@ ACTOR BaronAttack: BaronBall
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
 	+THRUGHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	Damage 25
 	Speed 28
@@ -1318,7 +1318,7 @@ ACTOR CallingTheBaronAFaggot: BaronBall
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
 	+THRUGHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	Damage (random (2, 3))
 	Speed 32

--- a/src/actors/Enemies/Bosses/IconOfSin.dec
+++ b/src/actors/Enemies/Bosses/IconOfSin.dec
@@ -226,7 +226,7 @@ ACTOR GatekeeperFireBall
 	Scale 1.3
 	+FORCEXYBILLBOARD
 	+THRUGHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	DamageType Extreme
 	ExplosionRadius 200
 	ExplosionDamage 100

--- a/src/actors/Enemies/Bosses/Motherdemon.dec
+++ b/src/actors/Enemies/Bosses/Motherdemon.dec
@@ -114,7 +114,7 @@ actor MotherFire
 	radius 6
 	damage 5
 	speed 15
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	alpha 0.5
 	damagetype "Vertigo"
 	seesound "skeleton/attack"
@@ -143,7 +143,7 @@ actor MotherFireTrail
 	radius 6
 	speed 0
 	damage 0
-	RenderStyle translucent
+	RenderStyle "Translucent"
 	Alpha 0.6
 	+NOGRAVITY
 	states
@@ -177,7 +177,7 @@ ACTOR SuperMotherBall : CacodemonBall
 	FastSpeed 25
 	Projectile
 	+RANDOMIZE
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 1
 	Scale 1.0
 	States

--- a/src/actors/Enemies/Cacodemo.dec
+++ b/src/actors/Enemies/Cacodemo.dec
@@ -550,7 +550,7 @@ ACTOR CacodemonBall_ Replaces CacodemonBall
 	+RANDOMIZE
 	+THRUGHOST
 	+FORCEXYBILLBOARD
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.95
 	damagetype Plasma
 	SeeSound "caco/attack"
@@ -603,7 +603,7 @@ ACTOR Shoque
 	+MISSILE
 	+FORCEXYBILLBOARD
 	+CLIENTSIDEONLY
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.7
 	Gravity 0
 	Alpha 0.5
@@ -629,7 +629,7 @@ ACTOR ShoqueAzul
 	+MISSILE
 	+FORCEXYBILLBOARD
 	+CLIENTSIDEONLY
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 1.0
 	Gravity 0
 	States

--- a/src/actors/Enemies/Cyberdemon.dec
+++ b/src/actors/Enemies/Cyberdemon.dec
@@ -446,7 +446,7 @@ ACTOR CyberStomp
 	+MISSILE
 	Speed 15
 	Damage 50
-	renderstyle translucent
+	RenderStyle "Translucent"
 	alpha 0.9
 	DamageType Stomp
 	Gravity 1.0

--- a/src/actors/Enemies/Demons.dec
+++ b/src/actors/Enemies/Demons.dec
@@ -1021,7 +1021,7 @@ ACTOR DemonAttack: BaronBall
 	+RIPPER
 	+FORCEXYBILLBOARD
 	+THRUGHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	SeeSound "dsempty"
 	DeathSound "dsempty"

--- a/src/actors/Enemies/Imps.dec
+++ b/src/actors/Enemies/Imps.dec
@@ -1336,7 +1336,7 @@ ACTOR ImpAttack: BaronBall
 	+FORCEXYBILLBOARD
 	+THRUGHOST
 	+BLOODSPLATTER 
-	RenderStyle none
+	RenderStyle "None"
 	+INVISIBLE
 	Alpha 0.6
 	HitObituary "$OB_IMPHIT"
@@ -1419,7 +1419,7 @@ ACTOR FireBall_ Replaces DoomImpBall
 	PROJECTILE
 	+THRUGHOST
 	+FORCEXYBILLBOARD
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 1
 	SeeSound "imp/attack"
 	DeathSound "imp/shotx"

--- a/src/actors/Enemies/Knight.dec
+++ b/src/actors/Enemies/Knight.dec
@@ -659,7 +659,7 @@ ACTOR GreenPlasmaBall: BaronBall Replaces BaronBall
 	+FORCEXYBILLBOARD
 	+THRUGHOST
 	Damage (random(50,50))
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.95
 	Scale 1.0
 	SeeSound "baron/attack"
@@ -695,7 +695,7 @@ ACTOR GreenPlasmaBall: BaronBall Replaces BaronBall
 
 ACTOR BaronBall_SlaughterFest: GreenPlasmaBall
 {
-	RenderStyle Add
+	RenderStyle "Add"
 	Decal "None"
 	DamageType "SFestExplode"
 	States
@@ -772,7 +772,7 @@ ACTOR KnightAttack: BaronBall
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
 	+THRUGHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	Damage 10
 	Speed 42

--- a/src/actors/Enemies/LABGUY.dec
+++ b/src/actors/Enemies/LABGUY.dec
@@ -937,7 +937,7 @@ ACTOR ZombieAxeAttack
 	+FORCEXYBILLBOARD
 	+THRUGHOST
 	+BLOODSPLATTER
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	HitObituary "$OB_IMPHIT"
 	Obituary "$OB_IMPHIT"

--- a/src/actors/Enemies/LostSoul.dec
+++ b/src/actors/Enemies/LostSoul.dec
@@ -26,7 +26,7 @@ ACTOR TehLostSoul: LostSoul Replaces LostSoul
 	damagefactor "TeleportRemover", 0.0
 	DamageFactor "CauseSplash", 0.0 DamageFactor "CauseObjectsToSplashSlime", 0.0 DamageFactor "CauseObjectsToSplashNukage", 0.0
 	DamageFactor "CauseObjectsToSplashBlood", 0.0 DamageFactor "CauseObjectsToSplashLava", 0.0
-	RenderStyle Normal
+	renderstyle "Normal"
 	bloodcolor ""
 	+FLOAT +NOGRAVITY +DONTFALL +NOICEDEATH
 	+FORCEXYBILLBOARD
@@ -290,7 +290,7 @@ ACTOR SoulTrails
 	+MISSILE
 	+FORCEXYBILLBOARD
 	+CLIENTSIDEONLY
-	RenderStyle Add
+	RenderStyle "Add"
 	DamageType Flames
 	Scale 0.5
 	Alpha 0.6

--- a/src/actors/Enemies/Mancubus.dec
+++ b/src/actors/Enemies/Mancubus.dec
@@ -694,7 +694,7 @@ ACTOR BigFireBall Replaces Fatshot
 	+FORCEXYBILLBOARD
 	+THRUGHOST
 	+GHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	DamageType Fire
 	ExplosionRadius 150
 	ExplosionDamage 8

--- a/src/actors/Enemies/Mastermind.dec
+++ b/src/actors/Enemies/Mastermind.dec
@@ -405,7 +405,7 @@ ACTOR MastermindStep
 	Height 32
 	Speed 0
 	Damage 50
-	renderstyle translucent
+	RenderStyle "Translucent"
 	alpha 0.75
 	DamageType Stomp
 	MeleeDamage 0

--- a/src/actors/Enemies/PainElemental.dec
+++ b/src/actors/Enemies/PainElemental.dec
@@ -180,7 +180,7 @@ ACTOR PEPart1
 	damagetype Blood
 	SeeSound "misc/xdeath4"
 	DeathSound "misc/xdeath1"
-	Decal BloodSuper
+	Decal "BloodSuper"
 	States
 	{
 	Spawn:
@@ -228,7 +228,7 @@ ACTOR PEPart2
 	damagetype Blood
 	SeeSound "misc/xdeath4"
 	DeathSound "misc/xdeath1"
-	Decal BloodSuper
+	Decal "BloodSuper"
 	States
 	{
 	Spawn:

--- a/src/actors/Enemies/Revenant.dec
+++ b/src/actors/Enemies/Revenant.dec
@@ -1140,7 +1140,7 @@ ACTOR REvenantAttack: BaronBall
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
 	+THRUGHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	Damage (random(15,15))
 	Speed 28

--- a/src/actors/Enemies/ST Monsters/Belphegor.dec
+++ b/src/actors/Enemies/ST Monsters/Belphegor.dec
@@ -275,7 +275,7 @@ ACTOR BelphegorGreenPlasmaBall: BaronBall
 	+FORCEXYBILLBOARD
 	+THRUGHOST
 	Damage (random(60,60))
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	Scale 1.6
 	SeeSound "baron/attack"

--- a/src/actors/Enemies/Spectre.dec
+++ b/src/actors/Enemies/Spectre.dec
@@ -4,7 +4,7 @@ ACTOR Spectro: BullDemon Replaces Spectre
 	-FASTER
 	DropItem "DemonStrengthRune" 2
 	DropItem "SpectreBlurSphere" 12
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.45
 	speed 8
 	fastspeed 6

--- a/src/actors/Enemies/Spiders.dec
+++ b/src/actors/Enemies/Spiders.dec
@@ -555,7 +555,7 @@ ACTOR SpiderPart1
 	damagetype Blood
 	SeeSound "misc/xdeath4"
 	DeathSound "misc/xdeath1"
-	Decal BloodSuper
+	Decal "BloodSuper"
 	States
 	{
 	Spawn:
@@ -593,7 +593,7 @@ ACTOR SpiderPart2
 	damagetype Blood
 	SeeSound "misc/xdeath4"
 	DeathSound "misc/xdeath1"
-	Decal BloodSuper
+	Decal "BloodSuper"
 	States
 	{
 	Spawn:

--- a/src/actors/Enemies/Spiders2.dec
+++ b/src/actors/Enemies/Spiders2.dec
@@ -459,7 +459,7 @@ ACTOR PurplePlasmaBall: FastProjectile
 	DamageType Blackhole
 	Damage 0
 	Decal StunnerScorch
-	RenderStyle Add
+	RenderStyle "Add"
 	SeeSound "PAILGF3"
 	DeathSound "PAILGD3"
 	Projectile
@@ -492,7 +492,7 @@ ACTOR MarinePurplePlasmaBall: PurplePlasmaBall
 
 ACTOR IonPuff: BulletPuff
 {
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.95
 	+NOBLOCKMAP
 	+NOGRAVITY

--- a/src/actors/Enemies/Volcabus.dec
+++ b/src/actors/Enemies/Volcabus.dec
@@ -720,7 +720,7 @@ ACTOR VolcabusBall
 	Scale 0.85
 	+FORCEXYBILLBOARD
 	+THRUGHOST
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	DamageType ExplosiveImpact
 	ExplosionRadius 150
 	ExplosionDamage 8

--- a/src/actors/Enemies/WCS/AAliens.dec
+++ b/src/actors/Enemies/WCS/AAliens.dec
@@ -541,7 +541,7 @@ ACTOR InvaderZimXdeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE

--- a/src/actors/Enemies/WCS/BWSS.dec
+++ b/src/actors/Enemies/WCS/BWSS.dec
@@ -6,7 +6,7 @@ ACTOR NaziKick: FastProjectile
 	Projectile 
 	+FORCEXYBILLBOARD
 	+NOEXTREMEDEATH
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	Damage 4
 	Speed 32
@@ -762,7 +762,7 @@ ACTOR BrutalWolfensteinXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE

--- a/src/actors/Enemies/WCS/DoomZero.dec
+++ b/src/actors/Enemies/WCS/DoomZero.dec
@@ -21,7 +21,7 @@ Actor AlphaLostSoul
 	damagefactor "TeleportRemover", 0.0
 	DamageFactor "CauseSplash", 0.0 DamageFactor "CauseObjectsToSplashSlime", 0.0 DamageFactor "CauseObjectsToSplashNukage", 0.0
 	DamageFactor "CauseObjectsToSplashBlood", 0.0 DamageFactor "CauseObjectsToSplashLava", 0.0
-	RenderStyle Normal
+	renderstyle "Normal"
 	bloodcolor ""
 	+FLOAT +NOGRAVITY +DONTFALL +NOICEDEATH
 	+FORCEXYBILLBOARD
@@ -360,7 +360,7 @@ ACTOR DoomZeroSpawnShot : SpawnShot
 
 ACTOR Pentagram
 {
-	Renderstyle Normal
+	renderstyle "Normal"
 	States
 	{
 	Spawn:

--- a/src/actors/Enemies/WCS/Evinty.dec
+++ b/src/actors/Enemies/WCS/Evinty.dec
@@ -684,7 +684,7 @@ Actor WhiteSmoke
 	+DontSPlash
 	+FORCEXYBILLBOARD
 	+CLIENTSIDEONLY
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.5
 	Gravity 0
 	Alpha 0.9
@@ -1048,7 +1048,7 @@ ACTOR ArchangelusTeleport
 	+EXPLODEONWATER
 	+MOVEWITHSECTOR
 	Gravity 0.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 5.0
 	Speed 0
 	States
@@ -1067,7 +1067,7 @@ ACTOR ArchangelusShield
 	Mass 5000
 	Radius 85
 	Height 85
-	RenderStyle Add
+	RenderStyle "Add"
 	XScale 3.0
 	YScale 2.5
 	+SOLID
@@ -1096,7 +1096,7 @@ ACTOR AstralCacoSpawner
 	+MOVEWITHSECTOR
 	+NOGRAVITY
 	Alpha 0.9
-	//RenderStyle Add
+	//RenderStyle "Add"
 	Scale 2.0
 	States
 	{
@@ -2235,7 +2235,7 @@ Actor TE_RainDrop// replaces JOM5_RainDrop
 	Height 1
 	Radius 1
 	//Renderstyle "Translucent"
-	//Renderstyle Add
+	//RenderStyle "Add"
 	Alpha 0.0
 	XScale 0.8
 	YScale 4.0
@@ -2281,7 +2281,7 @@ Actor TE_WaterRipple
 	height 1
 	mass 1
 	Health 600
-	RenderStyle Normal
+	renderstyle "Normal"
 	Alpha 0.52
 	+NOTELEPORT
 	+FORCEXYBILLBOARD

--- a/src/actors/Enemies/WCS/KeenNFriends.dec
+++ b/src/actors/Enemies/WCS/KeenNFriends.dec
@@ -430,7 +430,7 @@ Actor CometTail
 {
 	Projectile
 	+NoClip
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.4
 	States
 	{

--- a/src/actors/Gore/Blood.dec
+++ b/src/actors/Gore/Blood.dec
@@ -3,7 +3,7 @@
 actor Brutal_Blood Replaces Blood
 {
 	Decal BrutalBloodSplat
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	+FORCEXYBILLBOARD
 	+GHOST
 	+NOBLOCKMAP
@@ -145,7 +145,7 @@ ACTOR Brutal_FlyingBlood
 	radius 8
 	height 1
 	Gravity 0.8
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.9
 	Decal BrutalBlood
 	Mass 1
@@ -219,7 +219,7 @@ actor Brutal_FlyingBloodTrail
 {
 	scale 0.5
 	mass 1
-	renderstyle Normal
+	renderstyle "Normal"
 	Decal None
 	+NOTELEPORT
 	+NOBLOCKMAP
@@ -276,7 +276,7 @@ ACTOR Brutal_FlyingBloodFake: Brutal_FlyingBloodTrail
 	scale 0.5
 	speed 3
 	Gravity 0.3
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.95
 	+NOCLIP
 	Mass 1
@@ -911,7 +911,7 @@ ACTOR WaterBloodSpot
 	+THRUACTORS
 	Radius 0
 	Height 0
-	Renderstyle Shaded
+	renderstyle "Shaded"
 	StencilColor "55 00 00"
 	Alpha 0.2
 	states
@@ -1012,7 +1012,7 @@ actor GrowingBloodPool: Brutal_BloodSpot
 	height 1
 	mass 1
 	Health 600
-	RenderStyle Normal
+	renderstyle "Normal"
 	Alpha 0.99
 	+NOTELEPORT
 	+FORCEXYBILLBOARD
@@ -1301,7 +1301,7 @@ actor CeilBloodSpot
 	Scale 0.5
 	Gravity 0.0
 	Decal BrutalBloodSplat
-	Renderstyle Normal
+	renderstyle "Normal"
 	Alpha 0.9
 	states
 	{
@@ -1643,7 +1643,7 @@ ACTOR Underblood1
 	radius 8
 	height 1
 	Gravity 0.9
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.2
 	Decal BrutalBloodSplat
 	+MISSILE
@@ -1705,7 +1705,7 @@ actor SuperGore
 {
 	Decal BloodSplat
 	Alpha 0.6
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	+FORCEXYBILLBOARD
 	+GHOST
 	+NOBLOCKMAP
@@ -1785,7 +1785,7 @@ Actor SuperGoreSpawner
 	+MISSILE
 	+FORCEXYBILLBOARD
 	+THRUACTORS
-	Decal BloodSuper
+	Decal "BloodSuper"
 	radius 2
 	height 2
 	speed 15
@@ -1874,7 +1874,7 @@ ACTOR BootSmearerRed
 	+NOBLOCKMAP
 	+NOINTERACTION
 	+NOCLIP
-	RenderStyle none
+	RenderStyle "None"
 	Mass 0
 	Radius 0
 	Height 0
@@ -1968,7 +1968,7 @@ ACTOR RedBloodFootPrintRight: GrowingBloodPool
 actor DeadBlood
 {
 	Decal None
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	+FORCEXYBILLBOARD
 	+THRUACTORS
 	+CLIENTSIDEONLY

--- a/src/actors/Gore/BlueGore.dec
+++ b/src/actors/Gore/BlueGore.dec
@@ -277,7 +277,7 @@ ACTOR BlueWaterBloodCHecker: WaterBloodCHecker
 //muddy water bloodspot actor
 ACTOR BlueWaterBloodSpot: WaterBloodSpot
 {
-	Renderstyle Shaded
+	renderstyle "Shaded"
 	StencilColor "0 00 55"
 	Decal BlueBloodSplat
 	states

--- a/src/actors/Gore/Burn.dec
+++ b/src/actors/Gore/Burn.dec
@@ -68,7 +68,7 @@ ACTOR BurnParticles
 	-BLOODSPLATTER
 	+INVISIBLE
 	+NOINTERACTION
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:

--- a/src/actors/Gore/Dead.dec
+++ b/src/actors/Gore/Dead.dec
@@ -1708,7 +1708,7 @@ ACTOR SmallBloodPool2 Replaces SmallBloodPool
 	SpawnID 148
 	Radius 20
 	Height 1
-	RenderStyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	+MOVEWITHSECTOR
 	+CLIENTSIDEONLY

--- a/src/actors/Gore/GoreGroups.dec
+++ b/src/actors/Gore/GoreGroups.dec
@@ -5,7 +5,7 @@ ACTOR ZombieXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -73,7 +73,7 @@ ACTOR SargeXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -139,7 +139,7 @@ ACTOR ImpXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -204,7 +204,7 @@ ACTOR KnightXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -303,7 +303,7 @@ ACTOR CyberXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -342,7 +342,7 @@ ACTOR BullXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -405,7 +405,7 @@ ACTOR ChainXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -466,7 +466,7 @@ ACTOR MarineXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -524,7 +524,7 @@ ACTOR SpiderDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -575,7 +575,7 @@ ACTOR SkeletonXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -611,7 +611,7 @@ ACTOR SkeletonXDeathRare
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -646,7 +646,7 @@ ACTOR HalfManDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -682,7 +682,7 @@ ACTOR MeatDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -777,7 +777,7 @@ ACTOR MuchMeatDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -813,7 +813,7 @@ ACTOR RipGuts
 	Scale 0.8
 	Speed 1
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -846,7 +846,7 @@ ACTOR RipZombieMan
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -878,7 +878,7 @@ ACTOR FatalityZombieMan
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -912,7 +912,7 @@ ACTOR RipSergeant
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -945,7 +945,7 @@ ACTOR RipZombieman2
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -974,7 +974,7 @@ ACTOR RipImp
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -1007,7 +1007,7 @@ ACTOR CacoXDeath
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -1045,7 +1045,7 @@ ACTOR RipCaco
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	BounceFactor 0.5
 	+DOOMBOUNCE
 	+MISSILE
@@ -1078,7 +1078,7 @@ ACTOR BeheadZombieMan
 	Scale 0.8
 	Speed 0
 	Mass 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	+MISSILE
 	-EXPLODEONWATER
 	+NOBLOCKMAP

--- a/src/actors/Gore/GreenGore.dec
+++ b/src/actors/Gore/GreenGore.dec
@@ -272,7 +272,7 @@ ACTOR GreenWaterBloodCHecker: WaterBloodCHecker
 //muddy water bloodspot actor
 ACTOR GreenWaterBloodSpot: WaterBloodSpot
 {
-//Renderstyle Shaded
+//renderstyle "Shaded"
 	StencilColor "0 55 00"
 	Decal GreenBloodSplat
 	states

--- a/src/actors/Gore/Meat.dec
+++ b/src/actors/Gore/Meat.dec
@@ -60,7 +60,7 @@ ACTOR XDeath2: XDeath1
 	Height 2
 	Gravity 0.4
 	DeathSound "misc/xdeath2"
-	Decal BrutalBloodSuper
+	Decal "BrutalBloodSuper"
 	Scale 1.1
 	States
 	{
@@ -165,7 +165,7 @@ actor CeilXDeath2: Brutal_BloodSpot
 	+NOGRAVITY
 	+DontSplash
 	+CEILINGHUGGER
-	Renderstyle Normal 
+	renderstyle "Normal" 
 	Scale 1.1
 	states
 	{
@@ -231,7 +231,7 @@ ACTOR XDeath2NoStick: XDeath2
 ACTOR XDeath3: XDeath2
 {
 	DeathSound "misc/xdeath3"
-	Decal BrutalBloodSuper
+	Decal "BrutalBloodSuper"
 	Scale 1.1
 	States
 	{
@@ -557,7 +557,7 @@ ACTOR Guts
 	+CLIENTSIDEONLY
 	+FORCEXYBILLBOARD
 	+THRUACTORS
-	Decal BrutalBloodSplat
+	Decal "BrutalBloodSplat"
 	Scale 1.0
 	Gravity 0.4
 	States
@@ -634,7 +634,7 @@ ACTOR SmallBrainPiece: Xdeath2
 	Height 2
 	Speed 10
 	Scale 0.4
-	Decal None
+	Decal "None"
 	States
 	{
 	Spawn:
@@ -827,7 +827,7 @@ ACTOR GibEyeball
 	Height 2
 	Speed 6
 	Mass 1
-	Decal BrutalBloodSplat
+	Decal "BrutalBloodSplat"
 	+CLIENTSIDEONLY
 	BounceFactor 0.5
 	+DOOMBOUNCE
@@ -899,7 +899,7 @@ ACTOR BurningFlyingMeatPiece
 	damagetype Blood
 	SeeSound "misc/xdeath4"
 	DeathSound "misc/xdeath1"
-	Decal BloodSuper
+	Decal "BloodSuper"
 	States
 	{
 	Spawn:

--- a/src/actors/Hissy.dec
+++ b/src/actors/Hissy.dec
@@ -365,7 +365,7 @@ ACTOR FriendHissy_Guarding : FriendHissy
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		CACB A 0
 		TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
 		CACB A 4
 		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
@@ -468,6 +468,7 @@ ACTOR FriendHissyPathfinder
 	damagefactor "SpawnMarine", 99999.0
 	MaxDropOffHeight 1200
 	MaxStepHeight 1200
+	RenderStyle "None"
 	-COUNTKILL
 	+NOTARGET
 	+THRUACTORS

--- a/src/actors/Hissy.dec
+++ b/src/actors/Hissy.dec
@@ -527,7 +527,7 @@ ACTOR HissyFireball
 	+RANDOMIZE
 	+THRUSPECIES
 	+MTHRUSPECIES
-	RenderStyle Add
+	RenderStyle "Add"
 	Species "Marines"
 	Alpha 0.99
 	Scale 1.6

--- a/src/actors/LedgeGrab.dec
+++ b/src/actors/LedgeGrab.dec
@@ -6,6 +6,7 @@ Actor EdgeLord
 {
 	Radius 10
 	Height 28
+	RenderStyle "None"
 	States
 	{
 	Spawn:

--- a/src/actors/MISC/Artifact.dec
+++ b/src/actors/MISC/Artifact.dec
@@ -217,7 +217,7 @@ ACTOR SuperBlurSphere : CustomInventory //Replaces BlurSphere
 	+INVENTORY.ALWAYSPICKUP
 	+INVENTORY.BIGPOWERUP
 	+FORCEXYBILLBOARD
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Inventory.PickupSound "Pickup/Invis" 
 	Inventory.PickupMessage "$GOTINVIS" // "Partial Invisibility"
 	States

--- a/src/actors/MISC/Casing.dec
+++ b/src/actors/MISC/Casing.dec
@@ -2,7 +2,7 @@ ACTOR RifleCaseSpawn
 {
 	Speed 20
 	PROJECTILE
-	RenderStyle none
+	RenderStyle "None"
 	+NOCLIP
 	+CLIENTSIDEONLY
 	+NOINTERACTION

--- a/src/actors/MISC/FLARES.dec
+++ b/src/actors/MISC/FLARES.dec
@@ -1,7 +1,7 @@
 Actor Flare_General
 {
 	Mass 0
-	renderstyle Add
+	RenderStyle "Add"
 	radius 1
 	height 2
 	alpha 0.4
@@ -429,7 +429,7 @@ ACTOR PlayerMuzzle1
 	+NOINTERACTION
 	+CLIENTSIDEONLY
 	+FORCEXYBILLBOARD
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	States
 	{
 	Spawn:
@@ -457,7 +457,7 @@ ACTOR AutocannonMuzzle2
 	Speed 0
 	PROJECTILE
 	Scale 4.0
-	Renderstyle Add
+	RenderStyle "Add"
 	+NOCLIP
 	+NOGRAVITY
 	+NOINTERACTION
@@ -483,7 +483,7 @@ ACTOR MarineMuzzle1
 	+NOINTERACTION
 	+FORCEXYBILLBOARD
 	Speed 5
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:

--- a/src/actors/MISC/Fire.dec
+++ b/src/actors/MISC/Fire.dec
@@ -10,7 +10,7 @@ ACTOR FlameTrails
 	+CLIENTSIDEONLY
 	+THRUACTORS
 	+DOOMBOUNCE
-	RenderStyle add
+	RenderStyle "Add"
 	damagetype fire
 	Scale 0.5
 	Gravity 0
@@ -60,7 +60,7 @@ ACTOR BlueFlameTrails: FlameTrails
 ACTOR SmallFlameTrails: FlameTrails
 {
 	Scale 0.4
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -74,7 +74,7 @@ ACTOR SmallFlameTrails2: SmallFlameTrails
 {
 	Scale 0.4
 	Speed 1
-	Renderstyle aDD
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -92,7 +92,7 @@ ACTOR SmallFlameTrails3: SmallFlameTrails
 {
 	Scale 0.2
 	Speed 1
-	Renderstyle ADD
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -120,7 +120,7 @@ ACTOR ImpFireBallFlames1: SmallFlameTrails
 {
 	Scale 1.2
 	Speed 6
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -136,7 +136,7 @@ ACTOR ImpFireBallFlames2: SmallFlameTrails
 {
 	Scale 1.2
 	Speed 1
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -155,7 +155,7 @@ ACTOR NightmareImpFireBallFlames: ImpFireBallFlames2
 
 ACTOR FireBallExplosion: FlameTrails
 {
-	Renderstyle Add
+	RenderStyle "Add"
 	Scale 1.6
 	States
 	{
@@ -172,7 +172,7 @@ ACTOR ExplosionFlames: FlameTrails
 {
 	Scale 1.0
 	Speed 2
-	Renderstyle ADd
+	RenderStyle "Add"
 	+DOOMBOUNCE
 	States
 	{
@@ -190,7 +190,7 @@ ACTOR TankExplosionFlames: FlameTrails
 	Scale 1.0
 	Speed 12
 	+DOOMBOUNCE
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.9	
 	States
 	{
@@ -297,7 +297,7 @@ ACTOR ImBallGettingReady: FlameTrails
 	+NOCLIP
 	Scale 0.5
 	Speed 1
-	Renderstyle ADd
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -314,7 +314,7 @@ ACTOR BallGettingReadyGreen: ImBallGettingReady
 Speed 0
 -FORCEXYBILLBOARD
 Alpha 1.0
-Renderstyle Add
+RenderStyle "Add"
 	Scale 1.6
 	States
 	{
@@ -331,7 +331,7 @@ ACTOR RealisticFireSparks1: ImBallGettingReady
 	+NOINTERACTION
 	+NOCLIP
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	YScale 1.0
 	XScale -1.0
 	States
@@ -365,7 +365,7 @@ ACTOR RealisticFireSparks1Green: ImBallGettingReady
 	Speed 0
 	-FORCEXYBILLBOARD
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	YScale 1.0
 	XScale -1.0
 	States
@@ -383,7 +383,7 @@ ACTOR RealisticFireSparks1Blue: ImBallGettingReady
 	Speed 0
 	-FORCEXYBILLBOARD
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	Translation "112:127=[0,72,145]:[66,160,255]"
 	YScale 1.0
 	XScale -1.0
@@ -412,7 +412,7 @@ ACTOR RealFlameTrailsSmall
 	+NOINTERACTION
 	+NOCLIP
 	+NOINTERACTION
-	RenderStyle Add
+	RenderStyle "Add"
 	damagetype fire
 	Scale 0.8
 	Alpha 1.0
@@ -443,7 +443,7 @@ ACTOR CoolandNewFlameTrails: FlameTrails
 {
 	Scale 0.3
 	Speed 1
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -457,7 +457,7 @@ ACTOR CoolandNewFlameTrailsLong: FlameTrails
 {
 	Scale 0.6
 	Speed 1
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -476,7 +476,7 @@ ACTOR FireballExplosionFlames: FlameTrails
 {
 	Scale 0.8
 	Speed 1
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -489,7 +489,7 @@ ACTOR FireballExplosionFlamesSmall: FlameTrails
 {
 	Scale 0.8
 	Speed 1
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -553,7 +553,7 @@ ACTOR 100SmallFireFocusSpawnerz: BarrelExplosionSmokeColumn
 ACTOR SmallFireFocus24: BarrelExplosionSmokeColumn
 {
 	Alpha 0.9
-	RenderStyle ADD
+	RenderStyle "Add"
 	Scale 0.6
 	States
 	{
@@ -589,8 +589,8 @@ ACTOR FlyingBurningFuel
 	+THRUGHOST
 	+NODAMAGETHRUST
 	damagetype Fire
-	Decal Decal
-	Renderstyle Add
+	Decal "Decal"
+	RenderStyle "Add"
 	Mass 1
 	States
 	{
@@ -665,7 +665,7 @@ ACTOR FlamethrowerBurningStuff
 	+DONTFALL
 	+FORCERADIUSDMG
 	damagetype Fire
-	Renderstyle Add
+	RenderStyle "Add"
 	Gravity 0.1
 	Mass 0
 	States
@@ -745,7 +745,7 @@ ACTOR FlamethrowerBurningStuff
 
 ACTOR FlyingLava: FlyingBurningFuel
 {
-	Renderstyle ADd
+	RenderStyle "Add"
 	Alpha 1.0
 	Gravity 1.0
 	Speed 9
@@ -914,7 +914,7 @@ ACTOR FlamethrowerFireParticles
 	+NOCLIP
 	+FORCEXYBILLBOARD
 	damagetype fire
-	Renderstyle Add
+	RenderStyle "Add"
 	Scale 1.0
 	Alpha 0.9
 	Gravity 0
@@ -953,7 +953,7 @@ ACTOR FlamethrowerFireTrail
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	damagetype fire
-	Renderstyle Add
+	RenderStyle "Add"
 	//XScale 0.12
 	//YScale 0.2
 	Scale 0.2
@@ -1015,7 +1015,7 @@ ACTOR BurningGroundLowDamage
 	+NOCLIP
 	+FORCEXYBILLBOARD
 	-NOGRAVITY
-	RenderStyle none
+	RenderStyle "None"
 	DamageType Fire
 	Scale 1.0
 	Alpha 1.0
@@ -1051,7 +1051,7 @@ ACTOR SmallFireTrail: FlameTrails
 	Alpha 0.7
 	Radius 1
 	Height 1
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -1096,7 +1096,7 @@ ACTOR FlamethrowerMissile
 	+BOUNCEONFLOORS
 	+BOUNCEONCEILINGS
 	//+THRUACTORS
-	RenderStyle Add
+	RenderStyle "Add"
 	DamageType Fire
 	Decal "FlamethrowerScorch"
 	Scale 0.3
@@ -1271,7 +1271,7 @@ ACTOR TinyBurningPiece: BarrelExplosionSmokeColumn
 	Damagetype "Fire"
 	+CLIENTSIDEONLY
 	Alpha 0.9
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.9
 	+BRIGHT
 	States
@@ -1319,7 +1319,7 @@ ACTOR TinyBurningPieceInfinite: BarrelExplosionSmokeColumn
 	-CLIENTSIDEONLY
 	+NODAMAGETHRUST
 	Alpha 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.4
 	States
 	{
@@ -1380,7 +1380,7 @@ ACTOR PentagramSpawner
 	+CLIENTSIDEONLY
 	+NOCLIP
 	-NOGRAVITY
-	RenderStyle none
+	RenderStyle "None"
 	XScale 0.25
 	YScale 0.025
 	Alpha 1
@@ -1415,7 +1415,7 @@ ACTOR BurningPentagram: PentagramSpawner
 
 ACTOR PentagramOff: PentagramSpawner
 {
-	Renderstyle Normal
+	renderstyle "Normal"
 	States
 	{
 	Spawn:
@@ -1430,7 +1430,7 @@ ACTOR RailgunFlameTrails : FlameTrails
 {
 	Scale 0.4
 	Alpha 0.99
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -1443,7 +1443,7 @@ ACTOR RailgunFlameTrailsBlue : FlameTrails
 {
 	Scale 0.4
 	Alpha 0.99
-	Renderstyle Add
+	RenderStyle "Add"
 	+NOBLOCKMAP
 	+NOINTERACTION
 	States
@@ -1459,7 +1459,7 @@ ACTOR HighExplosiveFlames: FlameTrails
 	Scale 1.2
 	Speed 4
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -1478,7 +1478,7 @@ ACTOR HighExplosiveFlames2: FlameTrails
 	Scale 1.6
 	Speed 4
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -1498,7 +1498,7 @@ ACTOR HighExplosiveFlamesSmall: FlameTrails
 	Scale 0.7
 	Speed 1
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -1550,7 +1550,7 @@ ACTOR BackblastFlames1: FlameTrails
 	Alpha 1.0
 	-DOOMBOUNCE
 	-BOUNCEONWALLS
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -1589,7 +1589,7 @@ ACTOR HugeBackblastFlames1
 	PROJECTILE
 	Radius 24
 	Height 42
-	Renderstyle Add
+	RenderStyle "Add"
 	+THRUACTORS
 	+CLIENTSIDEONLY
 	+DOOMBOUNCE
@@ -1632,7 +1632,7 @@ ACTOR HDFlamesGFX1
 	+NOGRAVITY
 	+NOINTERACTION
 	+NOBLOCKMAP
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 1.0
 	Scale 2.0
 	States
@@ -1659,7 +1659,7 @@ ACTOR HDFlamesGFX1Big: HDFlamesGFX1
 ////BD damaging lava particles
 ACTOR BDFlyingLava: FlyingBurningFuel
 {
-	Renderstyle ADd
+	RenderStyle "Add"
 	Alpha 1.0
 	Gravity 1.0
 	Speed 9

--- a/src/actors/MISC/Head_Sys.dec
+++ b/src/actors/MISC/Head_Sys.dec
@@ -646,7 +646,7 @@ actor HeadHitbox
 	DamageType head
 	BloodType "Brutal_Blood", "SawBlood", "SawBlood"
 	PainChance 255
-	//Renderstyle none
+	//RenderStyle "None"
 	//-COUNTKILL +NOTARGET
 	//+NOGRAVITY +SHOOTABLE +NOTELEPORT +FORCERADIUSDMG -SOLID +NODAMAGETHRUST
 	//+THRUGHOST +NORADIUSDMG +GHOST +SERVERSIDEONLY -COUNTKILL +NOTAUTOAIMED
@@ -894,7 +894,7 @@ actor NobleHeadshot: HeadHitbox
 	BloodColor "DarkGreen"
 	Radius 12
 	Height 24
-	Decal GreenBloodSplat
+	Decal "GreenBloodSplat"
 	+DONTRIP
 	States
 	{

--- a/src/actors/MISC/Optimization.dec
+++ b/src/actors/MISC/Optimization.dec
@@ -7,17 +7,222 @@ ACTOR ClientSideSpawner
 	Height 0
 	Alpha 0.0
 	Mass 0
-	RenderStyle none
+	RenderStyle "none"
 	+INVISIBLE
 	+NOBLOCKMAP
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	+NOCLIP
+	+NOTARGET
 	States
 	{
 	Spawn:
 		TNT1 A 0 //first frame is empty because doom (and i dont trust NODELAY)
 		TNT1 A 0 //now put your particles here
+		stop
+	}
+}
+
+
+
+Actor SpritePrecacher
+{
+	Renderstyle "none"
+	+INVISIBLE
+	+NOINTERACTION
+	+CLIENTSIDEONLY
+	States
+	{
+	Spawn:
+		TNT1 A 0 //my beloved
+		//////////////////////gore
+		//generic + burn
+		BL8A A 0
+		BLHT A 0
+		BLOR A 0
+		BLUD A 0
+		BPDL A 0
+		BRTL A 0
+		BSPR A 0
+		GTXP A 0
+		GTXZ A 0
+		GUTS A 0
+		XDB5 A 0
+		XDB6 A 0
+		XDT1 A 0
+		XME5 A 0
+		XME8 A 0
+		XMT1 A 0
+		XMT2 A 0
+		BDT2 A 0
+		BDT3 A 0
+		CARB A 0
+		PBR1 A 0
+		XBRN A 0
+
+		//////////////////////weapons
+		
+		//////////////////////effects
+		//flares
+		FSO1 A 0
+		L2NB A 0
+		L2NG A 0
+		L2NR A 0
+		L2NY A 0
+		LENB A 0
+		LENG A 0
+		LENR A 0
+		LENS A 0
+		LENW A 0
+		LENY A 0
+		TLMF A 0
+		//flames
+		CFCF A 0
+		CFFX A 0
+		EFIR A 0
+		F1RE A 0
+		F2RE A 0
+		FIR1 A 0
+		FIR2 A 0
+		FIR3 A 0
+		FIR5 A 0
+		FIR6 A 0
+		FIRB A 0
+		FIRG A 0
+		FLME A 0
+		FLXB A 0
+		FLXP A 0
+		FR7X A 0
+		FRFX A 0
+		FRPB A 0
+		FRPG A 0
+		FRPR A 0
+		FX98 A 0
+		INFE A 0
+		NF3R A 0
+		NF4R A 0
+		PLAF A 0
+		SPFM A 0
+		SPFN A 0
+		SPGM A 0
+		SPGN A 0
+		SRKB A 0
+		SRKG A 0
+		SRKR A 0
+		TRKB A 0
+		TRKG A 0
+		TRKR A 0
+		X003 A 0
+		X004 A 0
+		//particles
+		BAL1 A 0
+		BAL2 A 0
+		BAL7 A 0
+		BFOG A 0
+		BPRT A 0
+		BPUF A 0
+		BUBL A 0
+		DUST A 0
+		FX33 A 0
+		FX34 A 0
+		FX57 A 0
+		FX58 A 0
+		GLSP A 0
+		JNK1 A 0
+		JNK2 A 0
+		JNK3 A 0
+		LIQU A 0
+		MANF A 0
+		MSBL A 0
+		OFOG A 0
+		PBAL A 0
+		PBEX A 0
+		PFOG A 0
+		SHOQ A 0
+		SPKB A 0
+		SPKG A 0
+		SPKN A 0
+		SPKO A 0
+		SPKS A 0
+		SPRK A 0
+		VFOG A 0
+		WOOD A 0
+		ZGPL A 0
+		//Explosions
+		DTXP A 0
+		EXP1 A 0
+		EXP2 A 0
+		EXP3 A 0
+		EXP4 A 0
+		EXP5 A 0
+		EXP6 A 0
+		EXP7 A 0
+		EXP8 A 0
+		EXPG A 0
+		EXPL A 0
+		EXPZ A 0
+		PLX6 A 0
+		PLX7 A 0
+		WTXP A 0
+		WTXZ A 0
+		XPAC A 0
+		//SFX
+		ASHY A 0
+		ASHZ A 0
+		BLHD A 0
+		BSPH A 0
+		BSPL A 0
+		CMMN A 0
+		DIRP A 0
+		IPF2 A 0
+		LSPL A 0
+		LVAS A 0
+		NKSH A 0
+		NSPL A 0
+		SDRT A 0
+		SHOK A 0
+		SHwK A 0
+		SLIM A 0
+		SPHB A 0
+		SPHG A 0
+		SPHR A 0
+		SPHW A 0
+		SPSH A 0
+		TFOG A 0
+		WSPH A 0
+		WSPL A 0
+		//smoke
+		BSP4 A 0
+		BSP5 A 0
+		ESMK A 0
+		FBB3 A 0
+		FBB4 A 0
+		FBB5 A 0
+		PUF2 A 0
+		PUF3 A 0
+		SB17 A 0
+		SB18 A 0
+		SM1K A 0
+		SM4K A 0
+		SM5K A 0
+		SM6K A 0
+		SM7K A 0
+		SM9K A 0
+		SMBK A 0
+		SMk2 A 0
+		SMK3 A 0
+		SMK5 A 0
+		SMOK A 0
+		SMWP A 0
+		TNT1 A 0
+		TNT1 A 0
+		TNT1 A 0
+		TNT1 A 0
+		TNT1 A 0
+		TNT1 A 0
+		TNT1 A 0
+
+		//////////////////////monsters
 		stop
 	}
 }

--- a/src/actors/MISC/PUFF.dec
+++ b/src/actors/MISC/PUFF.dec
@@ -1,6 +1,6 @@
 ACTOR MeleePuff: BulletPuff
 {
-	renderstyle none
+	RenderStyle "None"
 	alpha 0.5
 	Scale 1.5
 	DamageType Melee
@@ -115,7 +115,7 @@ ACTOR FatalitySmashingPuff: SmashingPuff
 
 ACTOR HitPuff Replaces BulletPuff
 {
-	renderstyle none
+	RenderStyle "None"
 	alpha 0.3
 	Scale 0.8
 	radius 1
@@ -186,7 +186,7 @@ DamageType Minor
 
 ACTOR RicoChet
 {
-	renderstyle Add
+	RenderStyle "Add"
 	alpha 1.0
 	-COUNTKILL
 	-SHOOTABLE
@@ -459,7 +459,7 @@ ACTOR RicoChet50Call : RicoChet
 
 ACTOR DirtRicochet: RicoChet
 {
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	alpha 0.5
 	Scale 0.5
 	Speed 2
@@ -476,7 +476,7 @@ ACTOR DirtRicochet: RicoChet
 
 ACTOR DirtRicochet2: DirtRicochet
 {
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	alpha 0.2
 	Scale 0.6
 	Speed 5
@@ -491,7 +491,7 @@ ACTOR DirtRicochet2: DirtRicochet
 
 ACTOR WaterRicochet: DirtRicochet
 {
-	renderstyle Add
+	RenderStyle "Add"
 	-NOGRAVITY
 	Gravity 0.5
 	Speed 4
@@ -511,7 +511,7 @@ ACTOR WaterRicochet: DirtRicochet
 
 ACTOR NukageRicochet: WaterRicochet
 {
-	renderstyle Add
+	RenderStyle "Add"
 	states
 	{
 	Spawn:
@@ -525,7 +525,7 @@ ACTOR NukageRicochet: WaterRicochet
 
 ACTOR BloodRicochet: WaterRicochet
 {
-	renderstyle Add
+	RenderStyle "Add"
 	states
 	{
 	Spawn:
@@ -538,7 +538,7 @@ ACTOR BloodRicochet: WaterRicochet
 
 ACTOR GiantWaterRicochet: RicoChet
 {
-	renderstyle add
+	RenderStyle "Add"
 	alpha 0.9
 	XScale 3.0
 	YScale 2.0
@@ -585,7 +585,7 @@ Actor ATBulletPuff: HitPuff
 {
 	Scale 0.4
 	DamageType Blast
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -599,7 +599,7 @@ Actor ATBulletPuff: HitPuff
 
 ACTOR SSawPuff: HitPuff
 {
-	renderstyle add
+	RenderStyle "Add"
 	scale 0.15
 	alpha 0.7
 	Radius 20
@@ -655,7 +655,7 @@ Actor PuffSmoke
 	radius 1
 	height 1
 	mass 1
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	alpha 0.9
 	Scale 1.5
 	Speed 1
@@ -671,7 +671,7 @@ Actor PuffSmoke
 
 ACTOR Sparks: BulletPuff
 {
-	renderstyle add
+	RenderStyle "Add"
 	alpha 0.8
 	+NOBLOCKMAP
 	+NOGRAVITY

--- a/src/actors/MISC/Particles.dec
+++ b/src/actors/MISC/Particles.dec
@@ -13,7 +13,7 @@ Actor ExplosionParticle
 	-NOGRAVITY
 	+THRUGHOST
 	+NOTELEPORT
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.8
 	Gravity 1
 	Speed 12
@@ -77,7 +77,7 @@ ACTOR ShotgunParticles: ExplosionParticle2
 	radius 8
 	height 1
 	Gravity 0.6
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.1
 	Alpha 0.9
 	States
@@ -220,7 +220,7 @@ Actor BluePlasmaParticle: ExplosionParticle
 Actor RailgunTrailParticle : BluePlasmaParticle
 {
 	Gravity 0.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.4
 	Speed 1
 	States
@@ -235,7 +235,7 @@ Actor RailgunTrailParticle : BluePlasmaParticle
 Actor BluePlasmaFire: BluePlasmaParticle
 {
 	+NoGravity
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.7
 	Alpha 0.9
 	Speed 0
@@ -252,7 +252,7 @@ Actor BluePlasmaFire: BluePlasmaParticle
 Actor PurplePlasmaFire: BluePlasmaFire
 {
 	+NoGravity
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.7
 	Alpha 0.9
 	Speed 4
@@ -276,7 +276,7 @@ Actor PlasmaParticleX: BluePlasmaParticle
 {
 	BounceFactor 0.1
 	Gravity 0.4
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 4.0
 	Speed 2
 	States
@@ -318,7 +318,7 @@ Actor PlasmaParticle: BluePlasmaParticle
 
 ACTOR RailPuff: BulletPuff
 {
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	alpha 0.9
 	Scale 1.3
 	+NOBLOCKMAP
@@ -340,7 +340,7 @@ ACTOR RailPuff: BulletPuff
 
 ACTOR ShortRailPuff: BulletPuff
 {
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	alpha 0.9
 	Scale 1.6
 	+NOBLOCKMAP
@@ -360,7 +360,7 @@ ACTOR ShortRailPuff: BulletPuff
 
 ACTOR PlasmaPuff: BulletPuff
 {
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.95
 	+NOBLOCKMAP
 	+NOGRAVITY
@@ -380,7 +380,7 @@ ACTOR PlasmaPuff: BulletPuff
 
 ACTOR RailgunPuff: BulletPuff
 {
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.95
 	+NOBLOCKMAP
 	+NOGRAVITY
@@ -433,7 +433,7 @@ ACTOR BarrelParticle
 ACTOR Shrapnel: BarrelParticle
 {
 	Scale 0.02
-	RenderStyle Add
+	RenderStyle "Add"
 	Gravity 0.8
 	Speed 13
 	-DOOMBOUNCE
@@ -455,7 +455,7 @@ Actor GlassPart : BarrelParticle
 	bouncefactor 0.2
 	speed 8
 	seesound ""
-	renderstyle translucent
+	RenderStyle "Translucent"
 	alpha 0.4
 	scale 0.2
 	translation "0:255=4:4"
@@ -753,7 +753,7 @@ ACTOR MudDust
 	+CLIENTSIDEONLY
 	+DOOMBOUNCE
 	+THRUACTORS
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.6
 	BounceFactor 0.01
 	Speed 12
@@ -872,7 +872,7 @@ ACTOR BrownCloud: MudDust
 	+THRUACTORS
 	+NOINTERACTION
 	Speed 1
-	Renderstyle Normal
+	renderstyle "Normal"
 	Alpha 1.0
 	Scale 3.5
 	States
@@ -1115,7 +1115,7 @@ ACTOR DirtChunk4 : WallChunk
 
 ACTOR LargeGlassParticle1: WallChunk
 {
-	Renderstyle Add
+	RenderStyle "Add"
 	Scale 0.6
 	Alpha 0.9
 	Speed 7
@@ -1157,7 +1157,7 @@ ACTOR BDExplosionparticles: ExplosionParticle2
 	Radius 1
 	Height 1
 	Alpha 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.6
 	Speed 1
 	Gravity 0.7
@@ -1195,7 +1195,7 @@ ACTOR BDExplosionparticles: ExplosionParticle2
 ACTOR ImpBallExplosionparticles : BDExplosionparticles
 {
 	Speed 1
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.3
 	aLPHA 1.0
 	States
@@ -1227,7 +1227,7 @@ ACTOR ImpBallExplosionparticles : BDExplosionparticles
 ACTOR KnightBallExplosionparticles : BDExplosionparticles
 {
 	Speed 1
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.5
 	Alpha 1.0
 	States
@@ -1727,7 +1727,7 @@ ACTOR PlasmaHitFogNew: ExplosionParticle2
 	Radius 1
 	Height 1
 	Alpha 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.3
 	Speed 3
 	+NOGRAVITY

--- a/src/actors/MISC/SPARKS.dec
+++ b/src/actors/MISC/SPARKS.dec
@@ -9,7 +9,7 @@ actor Spark_BD1
   +NOBLOCKMAP
   +MISSILE +NOBLOCKMAP +DOOMBOUNCE
   bouncefactor 0.3
-  renderstyle Add
+  RenderStyle "Add"
   scale 0.12
   Gravity 0.4
   states
@@ -53,7 +53,7 @@ actor SparkFlare_BD1
 +CLIENTSIDEONLY
   +NOINTERACTION
   +FORCEXYBILLBOARD
-  renderstyle Add
+  RenderStyle "Add"
   scale 1.0
   states
   {
@@ -91,7 +91,7 @@ actor BDSpark_Down
   +NOINTERACTION
   +INVISIBLE
   +NOBLOCKMAP
-  Renderstyle none
+  RenderStyle "None"
   states
   {
   Spawn:
@@ -173,7 +173,7 @@ actor BDSpark_Up
   +NOINTERACTION
   +INVISIBLE
   +NOBLOCKMAP
-  Renderstyle none
+  RenderStyle "None"
   states
   {
   Spawn:
@@ -257,7 +257,7 @@ actor Spark_UpOnce
   +NOINTERACTION
   +INVISIBLE
   +NOBLOCKMAP
-  Renderstyle none
+  RenderStyle "None"
   states
   {
   Spawn:
@@ -317,7 +317,7 @@ actor ShakeYourAss
   +CLIENTSIDEONLY
   +NOINTERACTION
   +INVISIBLE
-  Renderstyle none
+  RenderStyle "None"
   states
   {
   Spawn:

--- a/src/actors/MISC/Smoke.dec
+++ b/src/actors/MISC/Smoke.dec
@@ -14,7 +14,7 @@ ACTOR ExplosionSmoke
 	Radius 0
 	Height 0
 	Alpha 0.01
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Scale 1.2
 	Speed 1
 	Mass 0
@@ -202,7 +202,7 @@ ACTOR AltSmoke: ExplosionSmoke
 ACTOR ShinnySmoke: AltSmoke
 {
 	Scale 2.0
-	Renderstyle Add
+	RenderStyle "Add"
 }
 
 Actor PlasmaSmoke
@@ -217,7 +217,7 @@ Actor PlasmaSmoke
 	Height 1
 	Scale 2.0
 	Speed 1
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.4
 	States
 	{
@@ -321,7 +321,7 @@ Actor HitpuffSmoke
 	Height 1
 	Scale 0.7
 	Speed 1
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.4
 	States
 	{
@@ -393,7 +393,7 @@ Actor SmokeSpawner
 {
 	Speed 20
 	+NOCLIP
-	Renderstyle none
+	RenderStyle "None"
 	+CLIENTSIDEONLY
 	+NOBLOCKMAP
 	+NOINTERACTION
@@ -412,7 +412,7 @@ Actor SmokeSpawner11
 {
 	Speed 25
 	+NOCLIP
-	Renderstyle none
+	RenderStyle "None"
 	+CLIENTSIDEONLY
 	+NOBLOCKMAP
 	+NOINTERACTION
@@ -436,7 +436,7 @@ ACTOR ShotSmoke
 	+FORCEXYBILLBOARD
 	+MISSILE
 	Speed 1
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.06
 	+CLIENTSIDEONLY
 	Radius 0
@@ -454,7 +454,7 @@ ACTOR ShotSmoke
 ACTOR CasingSmoke: Shotsmoke
 {
 	Speed 1
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.4
 	Scale 0.07
 	States
@@ -472,7 +472,7 @@ actor CyberStep
 	+NOBLOCKMAP
 	+NOGRAVITY
 	+NOTELEPORT
-	renderstyle translucent
+	RenderStyle "Translucent"
 	alpha 0.75
 	Scale 0.5
 	states
@@ -529,7 +529,7 @@ ACTOR BarrelExplosionSmokeColumn
 	Radius 0
 	Height 0
 	Alpha 0.7
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	//Scale 0.4
 	//Scale 0.8
 	XScale 1.6
@@ -578,7 +578,7 @@ ACTOR ExplosionSimpleSmokeColumn: BarrelExplosionSmokeColumn
 	Radius 0
 	Height 0
 	Alpha 0.4
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	//Scale 0.4
 	//Scale 0.8
 	XScale 1.5
@@ -590,7 +590,7 @@ ACTOR MicroSmokeColumn: BarrelExplosionSmokeColumn
 	Radius 0
 	Height 0
 	Alpha 0.2
-	RenderStyle Add
+	RenderStyle "Add"
 	XScale 0.2
 	YScale 0.2
 	States
@@ -631,7 +631,7 @@ ACTOR BigBlackSmoke
 	Radius 1
 	Height 1
 	Alpha 0.8
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	XScale 1.1
 	YScale 1.4
 	Speed 2
@@ -739,7 +739,7 @@ ACTOR GunBarrelSmoke: ExplosionSmoke
 {
  
 	Alpha 0.01
-	RenderStyle Add
+	RenderStyle "Add"
 	XScale 0.12
 	YScale 0.15
 	Speed 1

--- a/src/actors/MapEnhancementSystem/MapSpecificDec.dec
+++ b/src/actors/MapEnhancementSystem/MapSpecificDec.dec
@@ -277,7 +277,7 @@ ACTOR BDECGrassSpawner: BDdecorationBase 15848
 	+INVISIBLE
 	+NOINTERACTION
 	+NOBLOCKMAP
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -296,7 +296,7 @@ ACTOR BDECGrassSpawnerLarge: BDdecorationBase
 	+INVISIBLE
 	+NOINTERACTION
 	+NOBLOCKMAP
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -923,7 +923,7 @@ Actor BDECbigfire
 	+LOOKALLAROUND
 	+CLIENTSIDEONLY
 	+FORCEYBILLBOARD
-	Renderstyle add
+	RenderStyle "Add"
 	Scale 1.5
 	+BRIGHT
 	states
@@ -969,7 +969,7 @@ ACTOR BDECrealisticFireSparksT1
 	+NOGRAVITY
 	+FLOAT
 	Alpha 1.0
-	Renderstyle Add
+	RenderStyle "Add"
 	YScale 2.0
 	XScale -2.0
 	States
@@ -1012,7 +1012,7 @@ ACTOR LightShaft 11017
 	Height 1
 	XScale 1.0
 	YScale 1.8
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.25
 	+NOINTERACTION
 	+NOBLOCKMAP
@@ -1059,7 +1059,7 @@ ACTOR BDECSmallShaft1Red 11018
 	damagefactor "KillMe", 0.0 damagefactor "Trample", 0.0
 	Health 60
 	Mass 999999
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 1.0
 	States
 	{
@@ -1139,7 +1139,7 @@ ACTOR DestroyedCeilLamp
 	+FORCEYBILLBOARD
 	+CLIENTSIDEONLY
 	+NOINTERACTION
-	Renderstyle Normal
+	renderstyle "Normal"
 	States
 	{
 	Spawn:
@@ -1160,7 +1160,7 @@ ACTOR FloorShaft1Red 11019
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	+FORCEYBILLBOARD
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.2
 	States
 	{
@@ -1476,7 +1476,7 @@ ACTOR BDECvolumetricLight 11027
 	Height 1
 	XScale 2.9
 	YScale 2.9
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.15
 	States
 	{
@@ -1764,7 +1764,7 @@ ACTOR BDecWhiteFlareCagedLamp
 	+NOINTERACTION +NOGRAVITY +CLIENTSIDEONLY
 	hEIGHT 1
 	rADIUS 1
-	Renderstyle ADd
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -2468,7 +2468,7 @@ ACTOR BDECRedLightWall1: BDdecorationBase
 	+FLOAT 
 	+NOGRAVITY 
 	-SHOOTABLE
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.2
 	XScale 0.6
 	YScale 0.8
@@ -2593,7 +2593,7 @@ ACTOR BDECNukageGlow
 	+THRUACTORS
 	+CLIENTSIDEONLY
 	+FORCEXYBILLBOARD
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.2
 	XScale 4.2
 	YScale 2.0
@@ -2648,7 +2648,7 @@ ACTOR BDECLargeFireFocus
 	+FORCEXYBILLBOARD
 	+NOGRAVITY
 	+FLOAT
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.2
 	XScale 4.2
 	YScale 2.0
@@ -2697,7 +2697,7 @@ ACTOR BDECAddRedLight
 	+THRUACTORS
 	+CLIENTSIDEONLY
 	+FORCEXYBILLBOARD
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -2710,13 +2710,13 @@ ACTOR BDECAddRedLight
 ACTOR BDECAddbLUELight :  BDECAddRedLight
 {
 	Radius 1
-	Renderstyle Add
+	RenderStyle "Add"
 }
 
 ACTOR BDECAddRedLightLarge :  BDECAddRedLight
 {
 	Radius 1
-	Renderstyle Add
+	RenderStyle "Add"
 	+NOGRAVITY
 	+FLOAT
 }
@@ -2724,7 +2724,7 @@ ACTOR BDECAddRedLightLarge :  BDECAddRedLight
 ACTOR BDECAddbLUELightLarge :  BDECAddRedLight
 {
 	Radius 1
-	Renderstyle Add
+	RenderStyle "Add"
 }
 
 ACTOR BDTitleMapThing 8347
@@ -3547,7 +3547,7 @@ Actor BDECWIndowGlass1: BDdestroyabledecorative
 	YScale 3.0
 	Radius 4
 	Height 128
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Obituary "$OB_GLASS"
 	Alpha 0.65
 	states
@@ -3578,7 +3578,7 @@ Actor BDECWindowColision1: BDdestroyabledecorative
 	Health 1
 	Radius 4
 	Height 128
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	states
 	{
 	Spawn:
@@ -3919,7 +3919,7 @@ ACTOR HookColision
 	+BLOODSPLATTER
 	+NOTARGET
 	+FRIENDLY
-	RenderStyle Add
+	RenderStyle "Add"
 	Speed 0
 	Scale 1.0
 	States
@@ -4106,7 +4106,7 @@ Actor BDECCandleCorridor
 {
 	+NOINTERACTION
 	+NOBLOCKMAP
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -4124,7 +4124,7 @@ Actor BDECJungleLine1
 {
 	+NOINTERACTION
 	+NOBLOCKMAP
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 		Spawn:
@@ -4145,7 +4145,7 @@ Actor BDECGrassLine1
 {
 	+NOINTERACTION
 	+NOBLOCKMAP
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -4178,7 +4178,7 @@ actor DeletusVeryLarge
 	+ACTIVATEMCROSS
 	+NOINTERACTION
 	+NOBLOCKMAP
-	RenderStyle none
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -4191,7 +4191,7 @@ actor DeletusVeryLarge
 Actor BDECFountain// 15858
 {
 	+THRUACTORS
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.7
 	Radius 4
 	Height 4
@@ -4377,7 +4377,7 @@ ACTOR BDECHellFire
 	Height 12
 	+THRUACTORS
 	damagetype Fire
-	Renderstyle Add
+	RenderStyle "Add"
 	Gravity 0.2
 	Mass 0
 	States
@@ -4402,7 +4402,7 @@ ACTOR BDECPentagram 25856
 	+CLIENTSIDEONLY
 	+NOCLIP
 	-NOGRAVITY
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	XScale 0.3
 	YScale 0.1
 	Alpha 1
@@ -4425,7 +4425,7 @@ ACTOR BDECPentagram 25856
 
 ACTOR BDSpawnBaron
 {
-	RenderStyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	+NOINTERACTION
 	+INVISIBLE
@@ -4448,7 +4448,7 @@ ACTOR BDSpawnCacodemon
 	+THRUACTORS
 	Height 60
 	Radius 2
-	RenderStyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	+NOINTERACTION
 	+INVISIBLE
@@ -4466,7 +4466,7 @@ ACTOR BDSpawnCacodemon
 
 ACTOR BDSpawnImps
 {
-	RenderStyle none
+	RenderStyle "None"
 	+NOBLOCKMAP
 	+NOINTERACTION
 	+INVISIBLE

--- a/src/actors/MeatShields/ZmanShield.dec
+++ b/src/actors/MeatShields/ZmanShield.dec
@@ -145,7 +145,7 @@ ACTOR ThrowedZman
 	DamageType Kick
 	BounceFactor 0.5
 	DamageFactor "Cut", 2.00 DamageFactor "Saw", 2.00 damagefactor "PussyGrab", 10.0
-	Decal BrutalBloodSuper
+	Decal "BrutalBloodSuper"
 	States
 	{
 	Spawn:

--- a/src/actors/PlayerClasses/23Player.dec
+++ b/src/actors/PlayerClasses/23Player.dec
@@ -5185,7 +5185,7 @@ ACTOR PlayerFlyingBlood
  health 1
  radius 8
  height 1
-	Decal BloodSuper
+	Decal "BloodSuper"
    +MISSILE
    +CLIENTSIDEONLY
    +NOTELEPORT

--- a/src/actors/PlayerClasses/BrutalChexQuest.dec
+++ b/src/actors/PlayerClasses/BrutalChexQuest.dec
@@ -370,7 +370,7 @@ ACTOR FlemoidAcidBall
 	Damage (random(10,15))
 	Projectile 
 	+RANDOMIZE
-	RenderStyle Add
+	RenderStyle "Add"
 	Damagetype "Slime"
 	Alpha 1
 	+THRUGHOST
@@ -400,7 +400,7 @@ ACTOR AcidBallTrails
 	+CLIENTSIDEONLY
 	+THRUACTORS
 	+NOGRAVITY
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.3
 	States
 	{
@@ -424,7 +424,7 @@ ACTOR FlyingAcidParticles
 	BounceFactor 0.01
 	Speed 6
 	Gravity 0.4
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.6
 	States
 	{
@@ -457,7 +457,7 @@ ACTOR FlemoidGib1
 	+FLOORCLIP
 	SeeSound "misc/xdeath4"
 	DeathSound "misc/xdeath1"
-	Decal BrutalBloodSplatGreen
+	Decal "BrutalBloodSplatGreen"
 	Mass 1
 	States
 	{

--- a/src/actors/PlayerClasses/CapturedMarine.dec
+++ b/src/actors/PlayerClasses/CapturedMarine.dec
@@ -699,7 +699,7 @@ ACTOR MarinePunch: BaronBall
 	+FORCEXYBILLBOARD
 	+THRUGHOST
 	+BLOODSPLATTER 
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	HitObituary "$OB_IMPHIT"
 	Obituary "$OB_IMPHIT"
@@ -826,7 +826,7 @@ Actor OrderTitle1
 	+THRUACTORS
 	+GHOST
 	+THRUGHOST
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.2
 	Speed 1
 	States

--- a/src/actors/PlayerClasses/DyingGuys.dec
+++ b/src/actors/PlayerClasses/DyingGuys.dec
@@ -2250,7 +2250,7 @@ ACTOR ZombiemanGotHisLegBlowed: DyingZombiemanNoArm
 
 ACTOR SergeantFatalizedByBaron: TeleportFog
 {
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 1.0
 	States
 	{
@@ -2414,7 +2414,7 @@ ACTOR FlyingImpaledSergeant
 	damagetype Blood
 	SeeSound "misc/xdeath4"
 	DeathSound "misc/xdeath1"
-	Decal BrutalBloodSplat
+	Decal "BrutalBloodSplat"
 	Mass 1
 	+NOBLOODDECALS
 	BloodType "DeadBlood", "SawBlood", "SawBlood"	

--- a/src/actors/PlayerClasses/Epic2Stuff.dec
+++ b/src/actors/PlayerClasses/Epic2Stuff.dec
@@ -112,7 +112,7 @@ Actor SimpleRAinDrop
 	Speed 0
 	Height 2
 	Radius 2
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.7
 	Scale 1.2
 	Mass 0
@@ -166,7 +166,7 @@ Actor TVRRainDrop
 	Speed 0
 	Height 2
 	Radius 2
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.7
 	Scale 1.0
 	Mass 0
@@ -219,7 +219,7 @@ ACTOR AltMap01Cloud
 	Projectile
 	+RANDOMIZE
 	+THRUACTORS
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 1
 	Scale 2.0
 	SeeSound "imp/attack"

--- a/src/actors/PlayerClasses/FlatDecals.dec
+++ b/src/actors/PlayerClasses/FlatDecals.dec
@@ -8,7 +8,7 @@ ACTOR DetectFloorBullet
 	height 1
 	Gravity 0.9
 	damage 0
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.70
 	DamageType Blood
 	+MISSILE
@@ -44,7 +44,7 @@ ACTOR DetectCeilBullet
 	height 1
 	Gravity 0.0
 	damage 0
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.70
 	DamageType Blood
 	+MISSILE
@@ -82,7 +82,7 @@ ACTOR DetectFloorCraterNoSplashes
 	height 4
 	Gravity 0.9
 	damage 0
-	Renderstyle Shaded
+	renderstyle "Shaded"
 	StencilColor "Black"
 	Alpha 0.70
 	DamageType Blood
@@ -121,7 +121,7 @@ ACTOR DetectFloorCrater
 	height 4
 	Gravity 0.9
 	damage 0
-	Renderstyle Shaded
+	renderstyle "Shaded"
 	StencilColor "Black"
 	Alpha 0.9
 	DamageType Blood
@@ -161,7 +161,7 @@ ACTOR DetectCeilCrater
 	height 1
 	Gravity 0.0
 	damage 0
-	Renderstyle Shaded
+	renderstyle "Shaded"
 	StencilColor "Black"
 	Alpha 0.9
 	DamageType Blood
@@ -198,7 +198,7 @@ ACTOR DetectFloorCraterSmall
 	height 4
 	Gravity 0.9
 	damage 0
-	Renderstyle Shaded
+	renderstyle "Shaded"
 	StencilColor "Black"
 	Alpha 0.9
 	DamageType Blood
@@ -237,7 +237,7 @@ ACTOR DetectCeilCraterSmall
 	height 1
 	Gravity 0.0
 	damage 0
-	Renderstyle Shaded
+	renderstyle "Shaded"
 	StencilColor "Black"
 	Alpha 0.9
 	DamageType Blood

--- a/src/actors/PlayerClasses/FootSteps.dec
+++ b/src/actors/PlayerClasses/FootSteps.dec
@@ -929,7 +929,7 @@ Actor TnkStep: FootStep
 	Height 12
 	Radius 8
 	Scale 0.7
-	Renderstyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0.2
 	States
 	{

--- a/src/actors/PlayerClasses/Player.dec
+++ b/src/actors/PlayerClasses/Player.dec
@@ -4341,7 +4341,7 @@ ACTOR PlayerFlyingBlood
 	health 1
 	radius 8
 	height 1
-	Decal BloodSuper
+	Decal "BloodSuper"
 	+MISSILE
 	+CLIENTSIDEONLY
 	+NOTELEPORT

--- a/src/actors/PlayerClasses/StealthMonsters.dec
+++ b/src/actors/PlayerClasses/StealthMonsters.dec
@@ -1,7 +1,7 @@
 ACTOR BrutalStealthArachnotron : Arachnotron Replaces StealthArachnotron
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
@@ -9,7 +9,7 @@ ACTOR BrutalStealthArachnotron : Arachnotron Replaces StealthArachnotron
 ACTOR BrutalStealthArchvile : TehArchvile Replaces StealthArchvile
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
@@ -17,14 +17,14 @@ ACTOR BrutalStealthArchvile : TehArchvile Replaces StealthArchvile
 ACTOR BrutalStealthBaron : BaronofHell2 Replaces StealthBaron
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthCacodemon : Cacodemon_ Replaces StealthCacodemon
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
@@ -33,56 +33,56 @@ ACTOR BrutalStealthCacodemon : Cacodemon_ Replaces StealthCacodemon
 ACTOR BrutalStealthChaingunGuy : ChaingunGuy1 Replaces StealthChaingunGuy
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthDemon : BullDemon Replaces StealthDemon
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthHellKnight : HellKnight2 Replaces StealthHellKnight
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthDoomImp : Imp Replaces StealthDoomImp
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthFatso : Mancubus Replaces StealthFatso
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthRevenant : Revenant1 Replaces StealthRevenant
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthShotgunGuy : ShotgunGuy1 Replaces StealthShotgunGuy
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 
 ACTOR BrutalStealthZombieMan : RifleZombie Replaces StealthZombieMan
 {
 	+STEALTH
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Alpha 0
 }
 

--- a/src/actors/PlayerClasses/Teleports.dec
+++ b/src/actors/PlayerClasses/Teleports.dec
@@ -8,7 +8,7 @@ ACTOR TeleportationFog Replaces TeleportFog
 	+SHOOTABLE
 	+NOBLOOD
 	+NOGRAVITY
-	Renderstyle Add
+	RenderStyle "Add"
 	DamageFactor "CancelTeleportFog", 9999.0
 	States
 	{
@@ -122,7 +122,7 @@ ACTOR FriendlymarineTFog
 	+SHOOTABLE
 	+NOBLOOD
 	+NOGRAVITY
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.5
 	States
 	{

--- a/src/actors/PlayerClasses/Water.dec
+++ b/src/actors/PlayerClasses/Water.dec
@@ -101,7 +101,7 @@ Actor SpawnBlueLiquidParticleX
 Actor BlueLiquidParticleX: BloodLiquidParticleX
 {
 	//Translation "176:191=192:196"
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	Scale 1.2
 	Speed 10
@@ -145,7 +145,7 @@ Actor BUBULZ
 	+DOOMBOUNCE
 	+NOTELEPORT
 	+DontSplash
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.5
 	Speed 2
 	States
@@ -249,7 +249,7 @@ ACTOR WaterExplosionPressure
 	Radius 0
 	Height 0
 	Alpha 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 2.0
 	Speed 2
 	+NOBLOCKMAP
@@ -282,7 +282,7 @@ ACTOR WaterExplosionPressure2
 	Radius 0
 	Height 0
 	Alpha 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 4.0
 	Speed 0
 	+NOBLOCKMAP
@@ -360,7 +360,7 @@ Actor BlueLiquidParticleXSmall
 	+DontSplash
 	BounceFactor 0.1
 	Gravity 0.5
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 1.5
 	Alpha 0.4
 	//Speed 2
@@ -395,10 +395,10 @@ Actor WaterParticleX
 	+CLIENTSIDEONLY
 	+NOTELEPORT
 	+DontSplash
-	decal watersplash
+	decal "watersplash"
 	BounceFactor 0.1
 	Gravity 0.1
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.25
 	Alpha 0.5
 	Translation "176:191=192:196"

--- a/src/actors/Tokens.dec
+++ b/src/actors/Tokens.dec
@@ -13,7 +13,7 @@ Actor bd_Token : Inventory
 	Height 0
 	Alpha 0.0
 	Mass 0
-	RenderStyle none
+	RenderStyle "None"
 }
 
 ACTOR TokenCleaner : CustomInventory

--- a/src/actors/VEHICLES/HeavyMachinegun.dec
+++ b/src/actors/VEHICLES/HeavyMachinegun.dec
@@ -333,7 +333,7 @@ ACTOR HeavyMachinegunProjectile: FastProjectile
 	+NOEXTREMEDEATH
 	+FORCEXYBILLBOARD
 	Gravity 0.1
-	RenderStyle Add
+	RenderStyle "Add"
 	damagetype "Minigun"
 	Alpha 1.0
 	Decal "BulletChip"
@@ -383,7 +383,7 @@ ACTOR HeavyMachinegunFlash: FastProjectile
 	+BLOODSPLATTER
 	+FORCEXYBILLBOARD
 	Gravity 0.1
-	RenderStyle Add
+	RenderStyle "Add"
 	damagetype "Blast"
 	Alpha 0.2
 	Scale 0.4
@@ -428,7 +428,7 @@ actor HeavyMachinegunHitsProjectiles
 actor HeavyMachinegunProjectileTracerTrail
 {
 	Scale 2.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+NOINTERACTION
 	+CLIENTSIDEONLY
@@ -577,7 +577,7 @@ Actor AutocannonPenetrator: AutoCannonProjectile
 actor AutoCannonTracerTrail
 {
 	Scale 0.8
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+NOINTERACTION
 	+CLIENTSIDEONLY
@@ -635,7 +635,7 @@ ACTOR heavyplasmaProjectile: FastProjectile
 	+FORCEXYBILLBOARD
 	+BRIGHT
 	Gravity 0.1
-	RenderStyle Add
+	RenderStyle "Add"
 	damagetype "Plasma"
 	Alpha 1.0
 	Decal "Scorch"
@@ -702,7 +702,7 @@ ACTOR heavyplasmaFlash: FastProjectile
 	-NOGRAVITY
 	+BLOODSPLATTER
 	Gravity 0.1
-	RenderStyle Add
+	RenderStyle "Add"
 	damagetype "Plasma"
 	Alpha 0.2
 	Scale 0.4
@@ -746,7 +746,7 @@ actor heavyplasmaHitsProjectiles
 actor heavyplasmaProjectileTracerTrail
 {
 	Scale 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+NOINTERACTION
 	+CLIENTSIDEONLY
@@ -763,7 +763,7 @@ actor heavyplasmaProjectileTracerTrail
 actor heavyplasmaProjectileHit
 {
 	Scale 2.1
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.7
 	+MISSILE
 	Speed 2

--- a/src/actors/VEHICLES/Mech.dec
+++ b/src/actors/VEHICLES/Mech.dec
@@ -773,7 +773,7 @@ ACTOR MechMachinegunProjectile
 	+BLOODSPLATTER
 	+NOEXTREMEDEATH
 	Gravity 0.2
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	damagetype "Blast"
 	Alpha 0.9
 	Scale 1.1

--- a/src/actors/VEHICLES/Repairs.dec
+++ b/src/actors/VEHICLES/Repairs.dec
@@ -46,7 +46,7 @@ ACTOR RepairMissile
 	Damage (random (8, 8))
 	Projectile
 	+RANDOMIZE
-	RenderStyle Add
+	RenderStyle "Add"
 	Species "VehicleSpecial"
 	DamageType Repair
 	Decal "BulletChip"
@@ -69,7 +69,7 @@ ACTOR RepairMissile
 
 ACTOR RepairToolRicochet: BulletPuff
 {
-	renderstyle Add
+	RenderStyle "Add"
 	alpha 0.7
 	+NOBLOCKMAP
 	+NOGRAVITY
@@ -557,7 +557,7 @@ Actor TankBlood
 	+NOBLOODDECALS
 	-BLOODSPLATTER
 	+CLIENTSIDEONLY
-	Renderstyle Add
+	RenderStyle "Add"
 	Speed 0
 	Scale 0.4
 	States

--- a/src/actors/VEHICLES/VehicleCrashes.dec
+++ b/src/actors/VEHICLES/VehicleCrashes.dec
@@ -14,7 +14,7 @@ ACTOR HitSides: FastProjectile
 	+FORCERADIUSDMG
 	+THRUGHOST
 	-NOCLIP
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 1
 	//DamageType Kick
 	States
@@ -261,7 +261,7 @@ ACTOR HitFrontTerminalSpeed: HitFront
 
 ACTOR SideBikeHitPuff: BulletPuff
 {
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	scale 0.15
 	alpha 0.7
 	+NOBLOCKMAP
@@ -372,7 +372,7 @@ ACTOR CrashSparks
 	BounceFactor 0.5
 	Damage 0
 	alpha 1.0
-	renderstyle add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -391,7 +391,7 @@ ACTOR TireSmoke
 	Radius 0
 	Height 0
 	Alpha 0.4
-	RenderStyle Add
+	RenderStyle "Add"
 	Speed 1
 	Scale 2.0
 	+NOBLOCKMAP
@@ -797,7 +797,7 @@ ACTOR HitDetectionBase: FastProjectile
 	+FORCERADIUSDMG
 	+THRUGHOST
 	-NOCLIP
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 1
 	//DamageType Kick
 	States
@@ -859,7 +859,7 @@ ACTOR HelicopterHitDetectionGround: HitDetectionBase
 
 ACTOR HelicopterCrashPuff: BulletPuff
 {
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	scale 0.15
 	alpha 0.7
 	+NOBLOCKMAP

--- a/src/actors/Weapons/Axe.dec
+++ b/src/actors/Weapons/Axe.dec
@@ -325,7 +325,7 @@ ACTOR AxeAttack: FastProjectile
 	+BLOODSPLATTER
 	+FORCEPAIN
 	//+RIPPER
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
     Damage (random(20,25))//(random(90,95))
     Speed 30//60
@@ -506,7 +506,7 @@ Actor AltAxeAttackNoDecal: AxeAttack
 
 ACTOR AxePuffs: HitPuff
 {
-	renderstyle Translucent
+	RenderStyle "Translucent"
 	scale 0.15
 	alpha 0.7
 	Radius 20

--- a/src/actors/Weapons/BFG.dec
+++ b/src/actors/Weapons/BFG.dec
@@ -169,7 +169,7 @@ Actor BFGTrailParticle
 	+FORCEXYBILLBOARD
 	+CLIENTSIDEONLY
 	+NOINTERACTION
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.2
 	States
 	{
@@ -299,7 +299,7 @@ Actor BFGDeathParticle
 	Radius 1
 	Mass 0
 	BounceFactor 0.5
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.16
 	+Missile
 	+NoBlockMap
@@ -340,7 +340,7 @@ Actor BFGDeathParticleSuperFast: BFGDeathParticleFast { Speed 20 }
 
 Actor SuperBFGExtra : BFGExtra Replaces BFGExtra
 {
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.75
 	Damage 2
 	Scale 0.6
@@ -383,7 +383,7 @@ Actor BFGExtraParticle
 	Height 0
 	Radius 0
 	Mass 0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.14
 	+Missile
 	+NOBLOCKMAP
@@ -425,7 +425,7 @@ Actor BFGSuperParticle
 	+DontSplash
 	+FORCEXYBILLBOARD
 	+NOINTERACTION
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.16
 	Speed 24
 	States
@@ -445,7 +445,7 @@ ACTOR GreenShockWave
 	Height 64
 	Radius 32
 	Scale 2.25
-	RenderStyle add
+	RenderStyle "Add"
 	Alpha 0.9
 	+DROPOFF
 	+NOBLOCKMAP
@@ -485,7 +485,7 @@ ACTOR BFGFOG
 	Radius 1
 	Height 1
 	Alpha 0.7
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.4
 	Speed 8
 	Gravity 0

--- a/src/actors/Weapons/BFG10k.dec
+++ b/src/actors/Weapons/BFG10k.dec
@@ -246,7 +246,7 @@ ACTOR BFG10K_Ball: FastProjectile
 	+FORCEXYBILLBOARD
 	Species "Marines"
 	Scale 1.0
-	renderstyle ADD
+	RenderStyle "Add"
 	alpha 0.99
 	Scale 0.4
 	DeathSound "weapons/plasmax"
@@ -290,7 +290,7 @@ ACTOR GreenExplosionFire
 	+CLIENTSIDEONLY
 	+NOINTERACTION
 	+NOCLIP
-	RenderStyle Add
+	RenderStyle "Add"
 	DamageType Flames
 	Scale 2.0
 	Alpha 1

--- a/src/actors/Weapons/DEFAULTWEAPON.dec
+++ b/src/actors/Weapons/DEFAULTWEAPON.dec
@@ -947,7 +947,7 @@ ACTOR FlashlightSource: FlashlightProjectile
 	Radius 2
 	Height 2
 	Speed 0
-	Renderstyle Add
+	RenderStyle "Add"
 	YScale 0.3
 	XScale 0.5
 	Alpha 0.9
@@ -1175,7 +1175,7 @@ ACTOR TE_UseAttack
 	+BLOODLESSIMPACT
 	+NOCLIP
 	+NODAMAGETHRUST
-	RenderStyle Add
+	RenderStyle "Add"
 	Obituary "none"
 	SeeSound "dsempty"
 	DeathSound "dsempty"

--- a/src/actors/Weapons/Dragonslayer.dec
+++ b/src/actors/Weapons/Dragonslayer.dec
@@ -135,7 +135,7 @@ ACTOR DSAttack: FastProjectile
 	+FORCEXYBILLBOARD
 	+FORCERADIUSDMG
 	+BLOODSPLATTER
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.6
 	Damage (random(200,200))
 	Speed 60

--- a/src/actors/Weapons/Explosives.dec
+++ b/src/actors/Weapons/Explosives.dec
@@ -209,6 +209,7 @@ Actor HugeRocketBackblast: RocketBackblast
 	damage (random(120,120))
 	Decal "BigScorch"
 	DamageType Fire
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -266,7 +267,8 @@ actor RocketExplosion
 	+MISSILE
 	Radius 2
 	Height 2
-	Damagetype ExplosiveImpact
+	Damagetype "ExplosiveImpact"
+	RenderStyle "None"
 	Obituary "$OBBD_ROCKETLAUNCHER"
 	States
 	{
@@ -275,8 +277,7 @@ actor RocketExplosion
 
 	Death:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("WhiteShockwave")
-		TNT1 A 3
+		TNT1 A 3 A_SpawnItem("WhiteShockwave")
 		TNT1 A 0 A_Explode(100,150)
 		Stop
 	}
@@ -288,7 +289,8 @@ actor LiquidExplosionEffectSpawner
 	+MISSILE
 	Radius 2
 	Height 2
-	Damagetype CauseWaterSplash
+	Damagetype "CauseWaterSplash"
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -308,8 +310,7 @@ actor BarrelExplosion: RocketExplosion
 
 	Death:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
-		TNT1 A 3
+		TNT1 A 3 A_SpawnItem("WhiteShockwaveBig")
 		TNT1 A 0 A_Explode(160,200)
 		Stop
 	}
@@ -325,8 +326,7 @@ actor TankMissileExplosion: RocketExplosion
 
 	Death:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
-		TNT1 A 3
+		TNT1 A 3 A_SpawnItem("WhiteShockwaveBig")
 		TNT1 A 0 A_Explode(200,300)
 		Stop
 	}
@@ -344,8 +344,7 @@ actor BarrelExplosionAnnouncer: RocketExplosion
 
 	Death:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
-		TNT1 A 3
+		TNT1 A 3 A_SpawnItem("WhiteShockwaveBig")
 		TNT1 A 0 A_Explode(3,220)
 		Stop
 	}
@@ -355,6 +354,7 @@ actor GrenadeExplosion: RocketExplosion
 {
 	+FORCERADIUSDMG
 	Obituary "$OBBD_GRENADELAUNCHER"
+	RenderStyle "None"
 	States	
 	{
 	Spawn:
@@ -369,6 +369,7 @@ actor GrenadeExplosion: RocketExplosion
 actor UGBLExplosion: RocketExplosion
 {
 	+FORCERADIUSDMG
+	RenderStyle "None"
 	Obituary "$OBBD_RIFLE_GRENADE"
 	States	
 	{
@@ -384,6 +385,7 @@ actor UGBLExplosion: RocketExplosion
 actor BFGSprayExplosion: RocketExplosion
 {
 	+FORCERADIUSDMG
+	RenderStyle "None"
 	DamageType "Desintegrate"
 	States
 	{
@@ -424,7 +426,7 @@ ACTOR GrenadeMissile
 	States
 	{
 	Spawn:
-		TNT1 A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
+		GBPJ A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
 		TNT1 A 0 A_GiveInventory("STGrenadeTimer", 1)
 		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 6, "Explode")
 		TNT1 A 0 A_CheckFloor("Death")
@@ -502,7 +504,7 @@ ACTOR ShortGrenade: GrenadeMissile
 	States
 	{
 	Spawn:
-		TNT1 A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
+		GBPJ A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
 		GBPJ AAAAAAAAABBBBBBBCCCCCDDDDDEEEEEFFFFFGGGGGHHHHH 1 A_CustomMissile ("DoxGrenadeSmokeTrail", 2, 0, random (70, 110), 2, random (0, 360))
 		Loop
 
@@ -559,7 +561,7 @@ ACTOR ShortGrenade2: GrenadeMissile
 	States
 	{
 	Spawn:
-		TNT1 A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
+		GBPJ A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
 		GBPJ AAAAAAAAABBBBBBBCCCCCDDDDDEEEEEFFFFFGGGGGHHHHH 1 A_CustomMissile ("DoxGrenadeSmokeTrail", 2, 0, random (70, 110), 2, random (0, 360))
 		Loop
 
@@ -613,8 +615,8 @@ ACTOR GrenadeMissileWeak: ShortGrenade
 	States
 	{
 	Spawn:
-		TNT1 A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
-		TNT1 A 0 A_CheckFloor("Death")
+		GBPJ A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
+		GBPJ A 0 A_CheckFloor("Death")
 		GBPJ AAAAAAAABBBBBBBCCCCCCC 1 A_CustomMissile ("RocketSmokeTrail52", 2, 0, random (70, 110), 2, random (0, 360))
 		GBPJ C -1 A_CustomMissile ("RocketSmokeTrail52", 2, 0, random (70, 110), 2, random (0, 360))
 		Goto Explode
@@ -663,6 +665,7 @@ ACTOR GrenadeMissileBreaksGlass: ShortGrenade
 {
 	-BLOODSPLATTER
 	Damagetype "Normal"
+	RenderStyle "None"
 	+NOPAIN
 	Decal "None"
 	Damage (random (1,2))
@@ -731,7 +734,7 @@ Actor DragonBreath
 	radius 1
 	height 1
 	speed 40
-	renderstyle ADD
+	renderstyle "none"
 	alpha 0.9
 	scale .15
 	DamageType Flames
@@ -744,9 +747,6 @@ Actor DragonBreath
 		Stop
 
 	Death:
-		Stop
-
-	XDeath:
 		TNT1 A 0
 		Stop
 	}
@@ -781,7 +781,7 @@ ACTOR CyberBalls: Rocket2
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		WYVB A 0
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckJanitor", 0, 0, 0, 0)//Check Effects
 
 	Spawn1:
@@ -844,7 +844,7 @@ ACTOR CyberballTrail
 	States
 	{
 	Spawn:
-		TNT1 A 2
+		WYVB A 0
 		WYVB CDE 1
 		Stop
 	}
@@ -874,8 +874,8 @@ ACTOR MarineGrenade
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		BLUD C 0 ThrustThingZ (0,50,1,0)
+		GRND A 0
+		GRND C 0 ThrustThingZ (0,50,1,0)
 	Live:
 		GRND ABCDEFGH 2
 		Loop
@@ -912,8 +912,8 @@ ACTOR ZombiemanGrenade: MarineGrenade
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		BLUD C 0 ThrustThingZ (0,50,1,0)
+		GRND A 0
+		GRND C 0 ThrustThingZ (0,50,1,0)
 	Live:
 		GRND ABCDEFGH 2
 		Loop
@@ -1014,9 +1014,7 @@ ACTOR TankFireEffect
 	States
 	{
 	Spawn:
-		TNT1 A 2
-		Goto Death
-
+		TKFL A 2
 	Death:
 		TNT1 A 0
 		TNT1 A 0 Radius_Quake(6, 12, 0, 4, 0)
@@ -1034,6 +1032,7 @@ ACTOR TankFireEffect
 ACTOR TankShotExplosionImpact
 {
 	damagetype "ExplosiveImpact"
+	RenderStyle "None"
 	+MISSILE
 	+NOCLIP
 	States

--- a/src/actors/Weapons/Explosives.dec
+++ b/src/actors/Weapons/Explosives.dec
@@ -5,7 +5,7 @@ ACTOR HorizontalShockwave
 	Radius 2
 	Height 4
 	Alpha 0.3
-	Renderstyle add
+	RenderStyle "Add"
 	Scale 1.0 //you could easily make a bigger shockwave by just changing the scale
 	+NOGRAVITY
 	-SOLID
@@ -112,7 +112,7 @@ Actor RocketBackblast: FastProjectile
 	Height 12
 	Alpha 0.9
 	Scale 1.0
-	Renderstyle ADd
+	RenderStyle "Add"
 	+RIPPER
 	+GHOST
 	+THRUGHOST
@@ -767,7 +767,7 @@ ACTOR CyberBalls: Rocket2
 	DamageType Extreme
 	Gravity 0.00
 	Decal "Scorch"
-	Renderstyle Add
+	RenderStyle "Add"
 	-NOGRAVITY
 	+EXTREMEDEATH
 	//+THRUGHOST
@@ -830,7 +830,7 @@ ACTOR CyberballTrail
 	Radius 0
 	Height 0
 	Alpha 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.9
 	Speed 2
 	+NOBLOCKMAP

--- a/src/actors/Weapons/FlameCannon.dec
+++ b/src/actors/Weapons/FlameCannon.dec
@@ -256,7 +256,7 @@ ACTOR Flames
 	+FORCEXYBILLBOARD
 	+RIPPER
 	+BLOODLESSIMPACT
-	RenderStyle Add
+	RenderStyle "Add"
 	DamageType Flames
 	Scale 2.0
 	Alpha 1

--- a/src/actors/Weapons/Flamethrower.dec
+++ b/src/actors/Weapons/Flamethrower.dec
@@ -243,7 +243,7 @@ ACTOR FlamethrowerProjectileNew
 	+NOTELEPORT
 	+DONTSPLASH
 	damagetype fire
-	Renderstyle Add
+	RenderStyle "Add"
 	XScale 0.15
 	YScale 0.15
 	Alpha 0.9

--- a/src/actors/Weapons/Flamethrower.dec
+++ b/src/actors/Weapons/Flamethrower.dec
@@ -251,8 +251,7 @@ ACTOR FlamethrowerProjectileNew
 	States
 	{
 	Spawn:
-		TNT1 A 1
-		//FLXB AACEGIKMN 1 BRIGHT
+		FLXB A 1
 		TNT1 AA 0 A_CustomMissile("Shotgunparticles2", 0, 0, random(-30, 30), 2, random(0, 20))
 		FLXB AB 1 bright 
 		TNT1 A 0 A_CustomMissile("ExplosionParticle", 0, 0, random(-10, 10), 2, random(0, 20))
@@ -290,8 +289,7 @@ ACTOR FlamethrowerProjectileNew2 : FlamethrowerProjectileNew
 	{
 
 	Spawn:
-		TNT1 A 1
-		//FLXB AACEGIKMN 1 BRIGHT
+		FLXB A 1
 		FLXB ABC 1 bright 
 		FLXP BCDEFG 1 BRIGHT
 		TNT1 A 0 A_CustomMissile ("FlamethrowerProjectileSmoke", 10, 0, random (0, 360), 2, random (60, 130))
@@ -333,26 +331,21 @@ ACTOR FlamethrowerProjectileSmoke
 	+NOGRAVITY
 	+DOOMBOUNCE
 	+THRUACTORS
-	Health 99999
 	BounceFactor 0.5
 	Radius 1
 	Height 1
 	Alpha 0.8
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Scale 2.0
 	Speed 0
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		SMBK A 0
 		SMBK ABCDEFGHIJKLMNOPQRSTUVWXYZ 2
-		Goto Death
-
-	Death:
-		TNT1 A 0
 		Stop
 
-	Stap:
+	Death:
 		TNT1 A 0
 		Stop
 	}

--- a/src/actors/Weapons/GrenadeLaunch.dec
+++ b/src/actors/Weapons/GrenadeLaunch.dec
@@ -418,10 +418,6 @@ Actor GrenadeCasingSpawner : ShotcaseSpawn
 	Spawn:
 		TNT1 A 0
 		TNT1 A 0 Thing_ChangeTID(0,390)
-		TNT1 A 0//1
-		Goto Death
-
-	Death:
 		TNT1 A 0 A_CustomMissile("GrenadeCasing",0,0,random(80,100),2,random(50,70))
 		Stop
 	}
@@ -471,76 +467,5 @@ ACTOR GrenadeCasing
 	Stoping:
 		TNT1 A 0
 		Stop
-	}
-}
-
-ACTOR GLTrailRed
-{
-	Radius 1
-	Height 2
-	Speed 0
-	RenderStyle Add
-	Scale 0.1
-	+FORCEXYBILLBOARD
-	+NOINTERACTION
-	+CLIENTSIDEONLY
-	+NOGRAVITY
-	+THRUACTORS
-	+BRIGHT
-	States
-	{
-	Spawn:
-		LEYS R 30 NODELAY
-		LEYS R 1 A_FadeOut(0.06)
-		wait
-	}
-}
-
-ACTOR GLTrailGreen : GLTrailRed
-{
-	States
-	{
-		Spawn:
-		LEYS G 30 NODELAY
-		LEYS G 1 A_FadeOut(0.06)
-		wait
-	}
-}
-
-ACTOR GLTrailYellow : GLTrailRed
-{
-	Scale 0.3
-	States
-	{
-		Spawn:
-		LEYS A 30 NODELAY
-		LEYS A 1 A_FadeOut(0.06)
-		wait
-	}
-}
-
-ACTOR GrenadeMissilePredictionTrail : GrenadeMissile //so it responsively takes the actual grenade's speed and other properties
-{
-	Damage (0)
-	+MISSILE
-	+THRUSPECIES
-	Species "Marines"
-	DamageType none
-	BounceSound "dsempty"
-	DeathSound "dsempty"
-	+USEBOUNCESTATE
-	+BRIGHT
-	States
-	{
-	//A_JumpIfInventory("STGrenadeTimer", 6, "Explode")
-	//A_GiveInventory("STGrenadeTimer", 1)
-	Spawn:
-		TNT1 A 0 NODELAY A_GiveInventory("STGrenadeTimer", 1)
-		TNT1 AAAAAAAAAAAA 1 A_SpawnItemEx("GLTrailRed",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION| SXF_CLIENTSIDE)
-		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 6, "Death")
-		loop
-	Death:
-		TNT1 A 2 A_SpawnItemEx("GLTrailYellow",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION| SXF_CLIENTSIDE)
-		stop
 	}
 }

--- a/src/actors/Weapons/Grenades.dec
+++ b/src/actors/Weapons/Grenades.dec
@@ -311,6 +311,7 @@ actor FragGrenadeExplosion
 	+MISSILE
 	+DONTSPLASH
 	Damagetype "Shrapnel"
+	RenderStyle "None"
 	Height 32
 	States
 	{

--- a/src/actors/Weapons/HellishMissile.dec
+++ b/src/actors/Weapons/HellishMissile.dec
@@ -293,7 +293,7 @@ ACTOR RevenantMissileFriendAttackSummon
 	Mass 999999999999999999
 	Health 1
 	gravity 0.5
-	Decal BloodSuper
+	Decal "BloodSuper"
 	+NOCLIP
 	MONSTER
 	+FRIENDLY

--- a/src/actors/Weapons/IncendiaryLauncher.dec
+++ b/src/actors/Weapons/IncendiaryLauncher.dec
@@ -131,7 +131,7 @@ Actor WillyPeteParticle
 	+THRUACTORS
 	+NODAMAGETHRUST
 	+USEBOUNCESTATE
-	RenderStyle Add
+	RenderStyle "Add"
 	Scale 0.8
 	Speed 16
 	Gravity 0.7
@@ -175,7 +175,7 @@ Actor WillyPeteParticleSmoke
 	+THRUACTORS
 	+NOGRAVITY
 	+FORCEXYBILLBOARD
-	RenderStyle Translucent
+	RenderStyle "Translucent"
 	Scale 0.1
 	Alpha 0.5
 	Speed 0
@@ -213,7 +213,7 @@ Actor IncendiaryRocketSmoke
 	+DOOMBOUNCE
 	Scale 4.0
 	Speed 1
-	Renderstyle Normal
+	renderstyle "Normal"
 	Alpha 1.0
 	States
 	{

--- a/src/actors/Weapons/Melee.dec
+++ b/src/actors/Weapons/Melee.dec
@@ -1600,7 +1600,7 @@ ACTOR PoorLostSoul
 	States
 	{
 	Spawn:
-		TNT1 A 0 A_CustomMissile ("FlameTrails", 24, 0, random(-2,2), 0, 0)
+		LSOL A 0 A_CustomMissile ("FlameTrails", 24, 0, random(-2,2), 0, 0)
 		LSOL B 2 BRIGHT A_SpawnItem("RedFlare",0,0)
 		Loop
 
@@ -1625,7 +1625,7 @@ ACTOR BarrelNukageSpawner
 	+THRUACTORS
 	+NOINTERACTION
 	+INVISIBLE
-	RenderStyle none
+	RenderStyle "none"
 	States
 	{
 	Spawn:
@@ -1647,15 +1647,15 @@ ACTOR ThrowedBarrel
 	Gravity 0.6
 	Scale 1.0
 	+FORCEXYBILLBOARD
-	DamageType Explosive
+	DamageType "Explosive"
 	Alpha 1
 	DeathSound "Barrel/explode"
 	tag "$TAGBD_THROWNBARREL"
 	States
 	{
 	Spawn:
-		TNT1 A 0 NODELAy A_Jump(128,"Stay")
-		TNT1 A 0 A_SetScale(-scalex,scaley)
+		TBRA A 0 NODELAy A_Jump(128,"Stay")
+		TBRA A 0 A_SetScale(-scalex,scaley)
 	Stay:
 		TBRA ABC 2
 		TBRA DEFG 2 A_SpawnItemEX("BarrelNukageSpawner",0,0,-30,0,0,0,random(0,128),SXF_NOCHECKPOSITION|SXF_CLIENTSIDE)
@@ -1705,7 +1705,7 @@ ACTOR KickAttack: FastProjectile
 	Projectile
 	+FORCEXYBILLBOARD
 	+NOEXTREMEDEATH
-	RenderStyle none
+	RenderStyle "none"
 	Damage (random(14,14))
 	Speed 30
 	Obituary "$OBBD_KICK"

--- a/src/actors/Weapons/NukeLauncher.dec
+++ b/src/actors/Weapons/NukeLauncher.dec
@@ -297,7 +297,7 @@ Actor NukeFlare
 	+NOGRAVITY
 	+FORCEXYBILLBOARD
 	+THRUACTORS
-	Renderstyle Add
+	RenderStyle "Add"
 	alpha 0.8
 	yscale 19.2
 	xscale 19.2
@@ -320,7 +320,7 @@ ACTOR NuclearFlames: ExplosionFlames
 {
 	Scale 2.2
 	Speed 5
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -347,7 +347,7 @@ ACTOR NuclearFlames2: ExplosionFlames
 {
 	Scale 3.5
 	Speed 5
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -375,7 +375,7 @@ ACTOR NuclearFlames3: ExplosionFlames
 	YScale 8.5
 	XScale 10.5
 	Speed 5
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:
@@ -391,7 +391,7 @@ ACTOR NuclearFlamesImpact: ExplosionFlames
 	-CLIENTSIDEONLY
 	+FORCERADIUSDMG
 	Damagetype "Nuke"
-	Renderstyle Add
+	RenderStyle "Add"
 	Alpha 0.25
 	States
 	{
@@ -406,7 +406,7 @@ ACTOR NuclearFlamesBig: ExplosionFlames
 {
 	Scale 9.2
 	Speed 3
-	Renderstyle Add
+	RenderStyle "Add"
 	States
 	{
 	Spawn:

--- a/src/actors/Weapons/NukeLauncher.dec
+++ b/src/actors/Weapons/NukeLauncher.dec
@@ -160,7 +160,7 @@ ACTOR NuclearRocket: Rocket2
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		MISL A 0
 		TNT1 A 0 A_PlaySound("Rocket/Fly")
 		TNT1 A 0 BRIGHT A_CustomMissile("RocketBackblast", 0, 0, 180, 2, 0+pitch)
 	Live:
@@ -189,6 +189,7 @@ ACTOR NuclearRocket: Rocket2
 Actor NuclearExplosion
 {
 	Damagetype "Nuke"
+	RenderStyle "None"
 	Radius 1
 	Height 1
 	States
@@ -240,7 +241,7 @@ Actor SpawnedExplosionNuke
 	Speed 2
 	Damagetype "Nuke"
 	+NOBLOCKMAP
-	renderstyle none
+	renderstyle "none"
 	states
 	{
 	Spawn:
@@ -271,7 +272,7 @@ Actor SpawnedExplosionNuke2
 	+NOBLOCKMAP
 	Radius 2
 	Height 2
-	renderstyle none
+	renderstyle "none"
 	states
 	{
 	Spawn:
@@ -303,8 +304,8 @@ Actor NukeFlare
 	states
 	{
 	Spawn:
-		TNT1 A 0
-		TNT1 A 0 A_SpawnItemEx("NuclearFlamesRepeat", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
+		LEYS A 0
+		LEYS A 0 A_SpawnItemEx("NuclearFlamesRepeat", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
 		LEYS O 120 BRIGHT
 		TNT1 A 0 A_SpawnItemEx("NuclearFlamesRepeat", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
 		LEYS oooooooooooooooooooooooo 2 BRIGHT a_fADEouT(0.02)
@@ -332,7 +333,7 @@ ACTOR NuclearFlamesRepeat: ExplosionFlames
 {
 	Scale 3.0
 	Speed 5
-	Renderstyle Add
+	Renderstyle "None"
 	States
 	{
 	Spawn:
@@ -359,7 +360,7 @@ ACTOR NuclearFlamesRepeat2: ExplosionFlames
 {
 	Scale 3.0
 	Speed 5
-	Renderstyle Add
+	Renderstyle "None"
 	States
 	{
 	Spawn:

--- a/src/actors/Weapons/Plasma.dec
+++ b/src/actors/Weapons/Plasma.dec
@@ -845,7 +845,7 @@ ACTOR Plasma_Ball: FastProjectile
 	damagefactor "Blood", 0.0 damagefactor "BlueBlood", 0.0 damagefactor "GreenBlood", 0.0 damagefactor "Taunt", 0.0 damagefactor "KillMe", 0.0 damagefactor "Shrapnel", 0.0
 	Health 5
 	Scale 1.0
-	renderstyle ADD
+	RenderStyle "Add"
 	alpha 0.99
 	DeathSound "Plasma/Impact"
 	//SeeSound "Plasma/Fire"

--- a/src/actors/Weapons/Railgun.dec
+++ b/src/actors/Weapons/Railgun.dec
@@ -696,7 +696,7 @@ Actor RailgunProjectile
 	Species "Marines"
 	Scale 1.0
 	var int user_railangle;
-	renderstyle ADD
+	RenderStyle "Add"
 	alpha 0.90
 	Scale 0.10
 	DeathSound "weapons/plasmax"
@@ -802,7 +802,7 @@ Actor RailgunPenetrator1B: RailgunPenetrator1
 Actor RailgunTracerTrail
 {
 	Scale 0.2
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+NOINTERACTION
 	+CLIENTSIDEONLY
@@ -884,7 +884,7 @@ Actor RailgunTrailEffect
 	+CLIENTSIDEONLY
 	+MISSILE
 	+NOGRAVITY
-	Renderstyle Add
+	RenderStyle "Add"
 	+NOBLOODDECALS
 	States
 	{

--- a/src/actors/Weapons/Saw.dec
+++ b/src/actors/Weapons/Saw.dec
@@ -511,7 +511,7 @@ ACTOR SawDamageHorizontal: FastProjectile
 	+FORCEXYBILLBOARD
 	+EXTREMEDEATH
 	+BLOODSPLATTER
-	RenderStyle none
+	RenderStyle "None"
 	Damage (random(5,6))
 	Speed 50
 	SeeSound "dsempty"

--- a/src/actors/Weapons/Tracers.dec
+++ b/src/actors/Weapons/Tracers.dec
@@ -282,6 +282,7 @@ Actor Alerter: MonsterTracer
 	damage (random(1,1))
 	DamageType Avoid
 	Decal "None"
+	RenderStyle "None"
 	States
 	{
 	Spawn:
@@ -601,7 +602,7 @@ Actor Penetrator: MarineTracer
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		TRAC A 0
 		TNT1 A 0 A_CustomMissile("SpawnBulletDecalBackwards", 0, 0, 0)
 		TRAC A 10 BRIGHT
 		Stop
@@ -669,7 +670,7 @@ Actor MonsterPenetrator: MarineTracer
 	States
 	{
 	Spawn:
-		TNT1 A 0
+		TRAC A 0
 		TNT1 A 0 A_CustomMissile("SpawnBulletDecalBackwards", 0, 0, 0)
 		TRAC A 10 BRIGHT
 		Stop

--- a/src/actors/Weapons/Tracers.dec
+++ b/src/actors/Weapons/Tracers.dec
@@ -11,7 +11,7 @@ Actor Tracer: FastProjectile
 	radius 2
 	height 2
 	speed 140
-	renderstyle ADD
+	RenderStyle "Add"
 	alpha 0.9
 	scale .15
 	Damagetype "Weak"
@@ -375,7 +375,7 @@ Actor MastermindTracer: Tracer
 	speed 80
 	damage (random(18,18))
 	scale 1.0
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	seesound "SSG/Fire"
 	damagetype ExplosiveImpact
@@ -443,7 +443,7 @@ Actor SuperMastermindTracer: MastermindTracer
 actor MastermindTracerTrail
 {
 	Scale 0.52
-	RenderStyle Add
+	RenderStyle "Add"
 	Alpha 0.9
 	+NOINTERACTION
 	+CLIENTSIDEONLY
@@ -505,7 +505,7 @@ Actor WallPenetrationHitscan: FastProjectile
 	radius 2
 	height 2
 	speed 900
-	renderstyle ADD
+	RenderStyle "Add"
 	alpha 0.9
 	scale .3
 	states
@@ -540,7 +540,7 @@ Actor SpawnBulletDecalBackwards: FastProjectile
 	radius 2
 	height 2
 	speed 50
-	renderstyle ADD
+	RenderStyle "Add"
 	Decal "BulletDecalNew1"
 	alpha 0.9
 	scale .3
@@ -572,7 +572,7 @@ Actor SpawnRocketDecalBackwards: FastProjectile
 	radius 6
 	height 2
 	speed 50
-	renderstyle ADD
+	RenderStyle "Add"
 	Decal "Scorch"
 	alpha 0.9
 	scale .3

--- a/src/actors/Weapons/Unmaker.dec
+++ b/src/actors/Weapons/Unmaker.dec
@@ -215,7 +215,7 @@ Actor UnmakerLaser: FastProjectile
 	radius 1
 	height 1
 	speed 500
-	renderstyle ADD
+	RenderStyle "Add"
 	alpha 0.9
 	scale .15
 	decal "scorch"
@@ -279,7 +279,7 @@ Actor UnmakerLaserTrail
 	+NOTELEPORT
 	+CANNOTPUSH
 	+NODAMAGETHRUST
-	renderstyle ADD
+	RenderStyle "Add"
 	alpha 0.9
 	scale .15
 	states


### PR DESCRIPTION
- RenderStyle and Decal properties now have their values surrounded in quotation marks
- Written a sprite precaching actor (for now it only precaches visual effects, needs to be implemented in the titlemap still)
- also small code cleanup across the board (TNT1 A sprites at the beginning of SPAWN states were changes to a proper sprite, so they would appear properly when spawned in via a console when the world is frozen)
- actors that only use TNT1 A were given RenderStyle "None", micro optimizations
- Slightly edited some unnessesarily ugly code